### PR TITLE
Add activity endpoints

### DIFF
--- a/backend/typescript/middlewares/validators/activityValidators.ts
+++ b/backend/typescript/middlewares/validators/activityValidators.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from "express";
+import { getApiValidationError, validatePrimitive } from "./util";
+
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable-next-line import/prefer-default-export */
+export const activityRequestDtoValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const { body } = req;
+  if (!validatePrimitive(body.activityName, "string")) {
+    return res
+      .status(400)
+      .send(getApiValidationError("activityName", "string"));
+  }
+
+  return next();
+};

--- a/backend/typescript/models/activity.model.ts
+++ b/backend/typescript/models/activity.model.ts
@@ -1,6 +1,6 @@
 import { Column, Model, Table } from "sequelize-typescript";
 
-@Table({ tableName: "activities" })
+@Table({ timestamps: false, tableName: "activities" })
 export default class Activities extends Model {
   @Column
   activity_name!: string;

--- a/backend/typescript/rest/activityRoutes.ts
+++ b/backend/typescript/rest/activityRoutes.ts
@@ -1,0 +1,102 @@
+import { Router } from "express";
+import { activityRequestDtoValidator } from "../middlewares/validators/activityValidators";
+import ActivityService from "../services/implementations/activityService";
+import {
+  ActivityResponseDTO,
+  IActivityService,
+} from "../services/interfaces/activityService";
+import { getErrorMessage, NotFoundError } from "../utilities/errorUtils";
+import { sendResponseByMimeType } from "../utilities/responseUtil";
+
+const activityRouter: Router = Router();
+
+const activityService: IActivityService = new ActivityService();
+
+/* Create Activity */
+activityRouter.post("/", activityRequestDtoValidator, async (req, res) => {
+  try {
+    const { body } = req;
+    const newActivity = await activityService.createActivity({
+      activityName: body.activityName,
+    });
+    res.status(201).json(newActivity);
+  } catch (e: unknown) {
+    if (e instanceof NotFoundError) {
+      res.status(404).send(getErrorMessage(e));
+    } else {
+      res.status(500).send("Internal server error occured.");
+    }
+  }
+});
+
+/* Get all Activities */
+activityRouter.get("/", async (req, res) => {
+  const contentType = req.headers["content-type"];
+  try {
+    const activities = await activityService.getActivities();
+    await sendResponseByMimeType<ActivityResponseDTO>(
+      res,
+      200,
+      contentType,
+      activities,
+    );
+  } catch (e: unknown) {
+    await sendResponseByMimeType(res, 500, contentType, [
+      {
+        error: "Internal server error occured.",
+      },
+    ]);
+  }
+});
+
+/* Get Activity by id */
+activityRouter.get("/:id", async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const activity = await activityService.getActivity(id);
+    res.status(200).json(activity);
+  } catch (e: unknown) {
+    if (e instanceof NotFoundError) {
+      res.status(404).send(getErrorMessage(e));
+    } else {
+      res.status(500).send("Internal server error occured.");
+    }
+  }
+});
+
+/* Update Activity by id */
+activityRouter.put("/:id", activityRequestDtoValidator, async (req, res) => {
+  const { id } = req.params;
+  try {
+    const { body } = req;
+    const activity = await activityService.updateActivity(id, {
+      activityName: body.activityName,
+    });
+    res.status(200).json(activity);
+  } catch (e: unknown) {
+    if (e instanceof NotFoundError) {
+      res.status(404).send(getErrorMessage(e));
+    } else {
+      res.status(500).send("Internal server error occured.");
+    }
+  }
+});
+
+/* Delete Activity by id */
+activityRouter.delete("/:id", async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const deletedId = await activityService.deleteActivity(id);
+    res.status(200).json({ id: deletedId });
+  } catch (e: unknown) {
+    if (e instanceof NotFoundError) {
+      res.status(404).send(getErrorMessage(e));
+    } else {
+      res.status(500).send("Internal server error occured.");
+    }
+  }
+});
+
+export default activityRouter;

--- a/backend/typescript/rest/activityRoutes.ts
+++ b/backend/typescript/rest/activityRoutes.ts
@@ -5,7 +5,11 @@ import {
   ActivityResponseDTO,
   IActivityService,
 } from "../services/interfaces/activityService";
-import { getErrorMessage, NotFoundError } from "../utilities/errorUtils";
+import {
+  getErrorMessage,
+  NotFoundError,
+  INTERNAL_SERVER_ERROR_MESSAGE,
+} from "../utilities/errorUtils";
 import { sendResponseByMimeType } from "../utilities/responseUtil";
 
 const activityRouter: Router = Router();
@@ -24,7 +28,7 @@ activityRouter.post("/", activityRequestDtoValidator, async (req, res) => {
     if (e instanceof NotFoundError) {
       res.status(404).send(getErrorMessage(e));
     } else {
-      res.status(500).send("Internal server error occured.");
+      res.status(500).send(INTERNAL_SERVER_ERROR_MESSAGE);
     }
   }
 });
@@ -43,7 +47,7 @@ activityRouter.get("/", async (req, res) => {
   } catch (e: unknown) {
     await sendResponseByMimeType(res, 500, contentType, [
       {
-        error: "Internal server error occured.",
+        error: INTERNAL_SERVER_ERROR_MESSAGE,
       },
     ]);
   }
@@ -60,7 +64,7 @@ activityRouter.get("/:id", async (req, res) => {
     if (e instanceof NotFoundError) {
       res.status(404).send(getErrorMessage(e));
     } else {
-      res.status(500).send("Internal server error occured.");
+      res.status(500).send(INTERNAL_SERVER_ERROR_MESSAGE);
     }
   }
 });
@@ -78,7 +82,7 @@ activityRouter.put("/:id", activityRequestDtoValidator, async (req, res) => {
     if (e instanceof NotFoundError) {
       res.status(404).send(getErrorMessage(e));
     } else {
-      res.status(500).send("Internal server error occured.");
+      res.status(500).send(INTERNAL_SERVER_ERROR_MESSAGE);
     }
   }
 });
@@ -94,7 +98,7 @@ activityRouter.delete("/:id", async (req, res) => {
     if (e instanceof NotFoundError) {
       res.status(404).send(getErrorMessage(e));
     } else {
-      res.status(500).send("Internal server error occured.");
+      res.status(500).send(INTERNAL_SERVER_ERROR_MESSAGE);
     }
   }
 });

--- a/backend/typescript/server.ts
+++ b/backend/typescript/server.ts
@@ -7,6 +7,7 @@ import YAML from "yamljs";
 
 import { sequelize } from "./models";
 import authRouter from "./rest/authRoutes";
+import activityRouter from "./rest/activityRoutes";
 import behaviourRouter from "./rest/behaviourRoutes";
 import entityRouter from "./rest/entityRoutes";
 import simpleEntityRouter from "./rest/simpleEntityRoutes";
@@ -33,6 +34,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 app.use("/auth", authRouter);
+app.use("/activities", activityRouter);
 app.use("/behaviours", behaviourRouter);
 app.use("/entities", entityRouter);
 app.use("/simple-entities", simpleEntityRouter);

--- a/backend/typescript/services/implementations/activityService.ts
+++ b/backend/typescript/services/implementations/activityService.ts
@@ -1,0 +1,119 @@
+import PgActivity from "../../models/activity.model";
+import {
+  IActivityService,
+  ActivityRequestDTO,
+  ActivityResponseDTO,
+} from "../interfaces/activityService";
+import { getErrorMessage, NotFoundError } from "../../utilities/errorUtils";
+import logger from "../../utilities/logger";
+
+const Logger = logger(__filename);
+
+class ActivityService implements IActivityService {
+  /* eslint-disable class-methods-use-this */
+  async getActivity(id: string): Promise<ActivityResponseDTO> {
+    let activity: PgActivity | null;
+    try {
+      activity = await PgActivity.findByPk(id, { raw: true });
+      if (!activity) {
+        throw new NotFoundError(`Activity id ${id} not found`);
+      }
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to get activity. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+
+    return {
+      id: activity.id,
+      activityName: activity.activity_name,
+    };
+  }
+
+  async getActivities(): Promise<ActivityResponseDTO[]> {
+    try {
+      const activities: Array<PgActivity> = await PgActivity.findAll({
+        raw: true,
+      });
+      return activities.map((activity) => ({
+        id: activity.id,
+        activityName: activity.activity_name,
+      }));
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to get activities. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  async createActivity(
+    activity: ActivityRequestDTO,
+  ): Promise<ActivityResponseDTO> {
+    let newActivity: PgActivity | null;
+    try {
+      newActivity = await PgActivity.create({
+        activity_name: activity.activityName,
+      });
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to create activity. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+    return {
+      id: newActivity.id,
+      activityName: newActivity.activity_name,
+    };
+  }
+
+  async updateActivity(
+    id: string,
+    activity: ActivityRequestDTO,
+  ): Promise<ActivityResponseDTO | null> {
+    let resultingActivity: PgActivity | null;
+    let updateResult: [number, PgActivity[]] | null;
+    try {
+      updateResult = await PgActivity.update(
+        {
+          activity_name: activity.activityName,
+        },
+        { where: { id }, returning: true },
+      );
+
+      if (!updateResult[0]) {
+        throw new NotFoundError(`Activity id ${id} not found`);
+      }
+      [, [resultingActivity]] = updateResult;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to update activity. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+    return {
+      id: resultingActivity.id,
+      activityName: resultingActivity?.activity_name,
+    };
+  }
+
+  async deleteActivity(id: string): Promise<string> {
+    try {
+      const deleteResult: number | null = await PgActivity.destroy({
+        where: { id },
+      });
+      if (!deleteResult) {
+        throw new NotFoundError(`Activity id ${id} not found`);
+      }
+      return id;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to delete activity. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+}
+
+export default ActivityService;

--- a/backend/typescript/services/interfaces/activityService.ts
+++ b/backend/typescript/services/interfaces/activityService.ts
@@ -1,0 +1,54 @@
+export interface ActivityRequestDTO {
+  activityName: string;
+}
+
+export interface ActivityResponseDTO {
+  id: number;
+  activityName: string;
+}
+
+export interface IActivityService {
+  /**
+   * retrieve the Activity with the given id
+   * @param id Activity id
+   * @returns requested Activity
+   * @throws Error if retrieval fails
+   */
+  getActivity(id: string): Promise<ActivityResponseDTO>;
+
+  /**
+   * retrieve all Activities
+   * @param
+   * @returns returns array of Activities
+   * @throws Error if retrieval fails
+   */
+  getActivities(): Promise<ActivityResponseDTO[]>;
+
+  /**
+   * create a Activity with the fields given in the DTO, return created Activity
+   * @param activity new Activity
+   * @returns the created Activity
+   * @throws Error if creation fails
+   */
+  createActivity(activity: ActivityRequestDTO): Promise<ActivityResponseDTO>;
+
+  /**
+   * update the Activity with the given id with fields in the DTO, return updated Activity
+   * @param id Activity id
+   * @param activity Updated Activity
+   * @returns the updated Activity
+   * @throws Error if update fails
+   */
+  updateActivity(
+    id: string,
+    activity: ActivityRequestDTO,
+  ): Promise<ActivityResponseDTO | null>;
+
+  /**
+   * delete the Activity with the given id
+   * @param id Activity id
+   * @returns id of the Activity deleted
+   * @throws Error if deletion fails
+   */
+  deleteActivity(id: string): Promise<string>;
+}


### PR DESCRIPTION
## Notion ticket link
<!-- https://www.notion.so/uwblueprintexecs/Pet-Activity-Endpoints-6b1f9d751a7f4f9180f27873194e48e7?pvs=4 -->
[ Pet Activity Endpoints ](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Implemented CRUD operations for activities table
* Removed create and update columns for activities table by setting "timestamps: false"
* Ensured proper error handling using NotFoundError
* ID parameter is a number except when returning deleted id

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test CRUD operations using Postman:
    a. Creating an activity returns created activity and updates database
<img width="1249" alt="Create Activity" src="https://github.com/uwblueprint/humane-society/assets/138075787/384f4b9c-5f63-419d-910a-172515ed2914">
    b. Getting all activities returns all activities in database
<img width="1249" alt="Get Activities " src="https://github.com/uwblueprint/humane-society/assets/138075787/76b2a050-de4f-455c-a9c3-644dcca689c9">
    c1. Getting an activity by id returns correct activity
<img width="1249" alt="Get Activity 2" src="https://github.com/uwblueprint/humane-society/assets/138075787/6d341271-6ec7-4ee6-9934-1b3b80e5d0cc">
    c2. Getting an activity with non-existent id returns a 404 error
<img width="1249" alt="Get Activity 3" src="https://github.com/uwblueprint/humane-society/assets/138075787/54b69179-2171-4405-b8a6-518f4c6b36f7">
    d1. Updating an activity returns updated activity and updates database
<img width="1249" alt="Update Activity 1" src="https://github.com/uwblueprint/humane-society/assets/138075787/dcbd04f7-e782-4fdf-898c-526ce03e7cb2">
    d2. Updating an activity with non-existent id returns a 404 error
<img width="1249" alt="Update Activity 10" src="https://github.com/uwblueprint/humane-society/assets/138075787/5876cbe1-f5fc-4800-a7dc-1ea9b5030953">
    e1. Deleting an activity returns deleted id and updates database
<img width="1249" alt="Delete Activity 1" src="https://github.com/uwblueprint/humane-society/assets/138075787/ceedb557-4d1c-4b5d-b5cf-0e973affccb4">
    e2. Deleting an activity with a non-existent id returns a 404 error
<img width="1249" alt="Delete Activity 30" src="https://github.com/uwblueprint/humane-society/assets/138075787/293f8fa2-8221-42a1-9aef-b9c8fdb5d3d4">
    e3. Updating an activity after deleting associated id returns a 404 error
<img width="1249" alt="Update Activity 1 After Deleting 1" src="https://github.com/uwblueprint/humane-society/assets/138075787/088e0d17-2ce8-43f6-aee0-c877de3e3dd3">
    e4. Getting all activities after deleting an activity returns updated activities
<img width="1249" alt="Get Activities After Deleting 1" src="https://github.com/uwblueprint/humane-society/assets/138075787/ffe79fe8-d4e1-4644-af73-10e9e7184d73">
    e5. Getting all activites after deleting all activites returns empty JSON
<img width="1249" alt="Get Activities After Deleting 1 and 2" src="https://github.com/uwblueprint/humane-society/assets/138075787/b4d1d39b-73b2-4ed9-8ea2-3a44decef356">




<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
