### PR TITLE
S24/trinity/adding pet relationship tables

### DIFF
--- a/backend/typescript/migrations/2024.07.06T15.03.01.create-pet-behaviour-table.ts
+++ b/backend/typescript/migrations/2024.07.06T15.03.01.create-pet-behaviour-table.ts
@@ -7,25 +7,25 @@ const TABLE_NAME = "pet_behaviours";
 export const up: Migration = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable(TABLE_NAME, {
     pet_id: {
-      type:DataType.INTEGER,
-      allowNull:false,
-      references:{
-        model:"pets",
-        key:"id",
+      type: DataType.INTEGER,
+      allowNull: false,
+      references: {
+        model: "pets",
+        key: "id",
       },
     },
     behaviour_id: {
-      type:DataType.INTEGER,
-      allowNull:false,
-      references:{
-        model:"behaviours",
-        key:"id",
+      type: DataType.INTEGER,
+      allowNull: false,
+      references: {
+        model: "behaviours",
+        key: "id",
       },
     },
     skill_level: {
-      type:DataType.INTEGER,
-      allowNull:false,
-    }
+      type: DataType.INTEGER,
+      allowNull: false,
+    },
   });
 };
 

--- a/backend/typescript/migrations/2024.07.06T15.03.01.create-pet-behaviour-table.ts
+++ b/backend/typescript/migrations/2024.07.06T15.03.01.create-pet-behaviour-table.ts
@@ -6,6 +6,10 @@ const TABLE_NAME = "pet_behaviours";
 
 export const up: Migration = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable(TABLE_NAME, {
+    id: {
+      type: DataType.INTEGER,
+      allowNull:false,
+    },
     pet_id: {
       type: DataType.INTEGER,
       allowNull: false,

--- a/backend/typescript/migrations/2024.07.06T15.03.01.create-pet-behaviour-table.ts
+++ b/backend/typescript/migrations/2024.07.06T15.03.01.create-pet-behaviour-table.ts
@@ -8,7 +8,9 @@ export const up: Migration = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable(TABLE_NAME, {
     id: {
       type: DataType.INTEGER,
-      allowNull:false,
+      autoIncrement: true,
+      primaryKey: true,
+      allowNull: false,
     },
     pet_id: {
       type: DataType.INTEGER,

--- a/backend/typescript/migrations/2024.07.06T15.03.01.create-pet-behaviour-table.ts
+++ b/backend/typescript/migrations/2024.07.06T15.03.01.create-pet-behaviour-table.ts
@@ -1,0 +1,34 @@
+import { DataType } from "sequelize-typescript";
+
+import { Migration } from "../umzug";
+
+const TABLE_NAME = "pet_behaviours";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().createTable(TABLE_NAME, {
+    pet_id: {
+      type:DataType.INTEGER,
+      allowNull:false,
+      references:{
+        model:"pets",
+        key:"id",
+      },
+    },
+    behaviour_id: {
+      type:DataType.INTEGER,
+      allowNull:false,
+      references:{
+        model:"behaviours",
+        key:"id",
+      },
+    },
+    skill_level: {
+      type:DataType.INTEGER,
+      allowNull:false,
+    }
+  });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().dropTable(TABLE_NAME);
+};

--- a/backend/typescript/migrations/2024.07.08T19.19.43.create-user-pet-activity.ts
+++ b/backend/typescript/migrations/2024.07.08T19.19.43.create-user-pet-activity.ts
@@ -6,60 +6,60 @@ const TABLE_NAME = "user_pet_activities";
 
 export const up: Migration = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable(TABLE_NAME, {
-    user_pet_activity_id:{
-      type:DataType.INTEGER,
-      allowNull:false,
-      primaryKey:true,
-      autoIncrement:true,
+    user_pet_activity_id: {
+      type: DataType.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
     },
-    user_id:{
-      type:DataType.INTEGER,
-      allowNull:true,
-      references:{
-        model:"users",
-        key:"id",
-      }
+    user_id: {
+      type: DataType.INTEGER,
+      allowNull: true,
+      references: {
+        model: "users",
+        key: "id",
+      },
     },
-    pet_id:{
-      type:DataType.INTEGER,
-      allowNull:false,
-      references:{
-        model:"pets",
-        key:"id",
-      }
+    pet_id: {
+      type: DataType.INTEGER,
+      allowNull: false,
+      references: {
+        model: "pets",
+        key: "id",
+      },
     },
-    activity_id:{
-      type:DataType.INTEGER,
-      allowNull:false,
-      references:{
-        model:"activities",
-        key:"id",
-      }
+    activity_id: {
+      type: DataType.INTEGER,
+      allowNull: false,
+      references: {
+        model: "activities",
+        key: "id",
+      },
     },
-    scheduled_start_time:{
-      type:DataType.DATE,
-      allowNull:true, 
+    scheduled_start_time: {
+      type: DataType.DATE,
+      allowNull: true,
     },
-    start_time:{
-      type:DataType.DATE,
-      allowNull:true,
+    start_time: {
+      type: DataType.DATE,
+      allowNull: true,
     },
-    end_time:{
-      type:DataType.DATE,
-      allowNull:true,
+    end_time: {
+      type: DataType.DATE,
+      allowNull: true,
     },
-    notes:{
-      type:DataType.TEXT,
-      allowNull:true,
+    notes: {
+      type: DataType.TEXT,
+      allowNull: true,
     },
     created_at: {
-      type:DataType.DATE,
-      allowNull:false,
+      type: DataType.DATE,
+      allowNull: false,
     },
     updated_at: {
-      type:DataType.DATE,
-      allowNull:true,
-    }
+      type: DataType.DATE,
+      allowNull: true,
+    },
   });
 };
 

--- a/backend/typescript/migrations/2024.07.08T19.19.43.create-user-pet-activity.ts
+++ b/backend/typescript/migrations/2024.07.08T19.19.43.create-user-pet-activity.ts
@@ -1,0 +1,68 @@
+import { DataType } from "sequelize-typescript";
+
+import { Migration } from "../umzug";
+
+const TABLE_NAME = "user_pet_activities";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().createTable(TABLE_NAME, {
+    user_pet_activity_id:{
+      type:DataType.INTEGER,
+      allowNull:false,
+      primaryKey:true,
+      autoIncrement:true,
+    },
+    user_id:{
+      type:DataType.INTEGER,
+      allowNull:true,
+      references:{
+        model:"users",
+        key:"id",
+      }
+    },
+    pet_id:{
+      type:DataType.INTEGER,
+      allowNull:false,
+      references:{
+        model:"pets",
+        key:"id",
+      }
+    },
+    activity_id:{
+      type:DataType.INTEGER,
+      allowNull:false,
+      references:{
+        model:"activities",
+        key:"id",
+      }
+    },
+    scheduled_start_time:{
+      type:DataType.DATE,
+      allowNull:true, 
+    },
+    start_time:{
+      type:DataType.DATE,
+      allowNull:true,
+    },
+    end_time:{
+      type:DataType.DATE,
+      allowNull:true,
+    },
+    notes:{
+      type:DataType.TEXT,
+      allowNull:true,
+    },
+    created_at: {
+      type:DataType.DATE,
+      allowNull:false,
+    },
+    updated_at: {
+      type:DataType.DATE,
+      allowNull:true,
+    }
+  });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().dropTable(TABLE_NAME);
+};

--- a/backend/typescript/migrations/2024.07.08T19.19.43.create-user-pet-activity.ts
+++ b/backend/typescript/migrations/2024.07.08T19.19.43.create-user-pet-activity.ts
@@ -6,7 +6,7 @@ const TABLE_NAME = "user_pet_activities";
 
 export const up: Migration = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable(TABLE_NAME, {
-    user_pet_activity_id: {
+    id: {
       type: DataType.INTEGER,
       allowNull: false,
       primaryKey: true,

--- a/backend/typescript/models/activity.model.ts
+++ b/backend/typescript/models/activity.model.ts
@@ -1,6 +1,6 @@
 import { Column, Model, Table } from "sequelize-typescript";
 
-@Table({ timestamps:false, tableName: "activities" })
+@Table({ timestamps: false, tableName: "activities" })
 export default class Activity extends Model {
   @Column
   activity_name!: string;

--- a/backend/typescript/models/activity.model.ts
+++ b/backend/typescript/models/activity.model.ts
@@ -1,7 +1,7 @@
 import { Column, Model, Table } from "sequelize-typescript";
 
 @Table({ tableName: "activities" })
-export default class Activities extends Model {
+export default class Activity extends Model {
   @Column
   activity_name!: string;
 }

--- a/backend/typescript/models/petBehaviour.ts
+++ b/backend/typescript/models/petBehaviour.ts
@@ -1,0 +1,23 @@
+import { Column, Model, Table, DataType, ForeignKey, BelongsTo } from "sequelize-typescript";
+import Behaviour from "./behaviour.model";
+import Pet from "./pet.model";
+
+@Table({ timestamps:false, tableName: "pet_behaviours" })
+export default class PetBehaviour extends Model {
+  @ForeignKey (()=> Pet)
+  @Column({})
+  pet_id!: number;
+
+  @BelongsTo (()=>Pet)
+  pet!: Pet;
+
+  @ForeignKey (()=> Behaviour)
+  @Column({})
+  behaviour_id!: number;
+  
+  @BelongsTo (()=>Behaviour)
+  behaviour!: Behaviour;
+
+  @Column({})
+  skill_level!: number;
+}

--- a/backend/typescript/models/petBehaviour.ts
+++ b/backend/typescript/models/petBehaviour.ts
@@ -1,21 +1,27 @@
-import { Column, Model, Table, DataType, ForeignKey, BelongsTo } from "sequelize-typescript";
+import {
+  Column,
+  Model,
+  Table,
+  ForeignKey,
+  BelongsTo,
+} from "sequelize-typescript";
 import Behaviour from "./behaviour.model";
 import Pet from "./pet.model";
 
-@Table({ timestamps:false, tableName: "pet_behaviours" })
+@Table({ timestamps: false, tableName: "pet_behaviours" })
 export default class PetBehaviour extends Model {
-  @ForeignKey (()=> Pet)
+  @ForeignKey(() => Pet)
   @Column({})
   pet_id!: number;
 
-  @BelongsTo (()=>Pet)
+  @BelongsTo(() => Pet)
   pet!: Pet;
 
-  @ForeignKey (()=> Behaviour)
+  @ForeignKey(() => Behaviour)
   @Column({})
   behaviour_id!: number;
-  
-  @BelongsTo (()=>Behaviour)
+
+  @BelongsTo(() => Behaviour)
   behaviour!: Behaviour;
 
   @Column({})

--- a/backend/typescript/models/userPetActivity.ts
+++ b/backend/typescript/models/userPetActivity.ts
@@ -1,0 +1,50 @@
+// not started
+import { Column, Model, Table, DataType, ForeignKey, BelongsTo } from "sequelize-typescript";
+import User from "./user.model";
+import Pet from "./pet.model";
+import Activity from "./activity.model";
+
+@Table({ timestamps:false, tableName: "user_pet_activities" })
+export default class UserPetActivity extends Model {
+  @Column({})
+  user_pet_activity_id!: number;
+
+  @ForeignKey (()=> User) // in case of null, task has not been assigned
+  @Column({})
+  user_id?: number;
+
+  @BelongsTo (()=>User)
+  user?: User;
+
+  @ForeignKey (()=> Pet)
+  @Column({})
+  pet_id!: number;
+
+  @BelongsTo (()=>Pet)
+  pet!: Pet;
+
+  @ForeignKey (()=> Activity)
+  @Column({})
+  activity_id!: number;
+  
+  @BelongsTo (()=> Activity)
+  activity!: Activity;
+
+  @Column({})
+  scheduled_start_time?: Date;
+
+  @Column({})
+  start_time?: Date;
+
+  @Column({})
+  end_time?: Date;
+
+  @Column({type: DataType.TEXT})
+  notes?: string;
+
+  @Column({})
+  created_at!: Date;
+
+  @Column({})
+  updated_at?: Date;
+}

--- a/backend/typescript/models/userPetActivity.ts
+++ b/backend/typescript/models/userPetActivity.ts
@@ -1,33 +1,40 @@
 // not started
-import { Column, Model, Table, DataType, ForeignKey, BelongsTo } from "sequelize-typescript";
+import {
+  Column,
+  Model,
+  Table,
+  DataType,
+  ForeignKey,
+  BelongsTo,
+} from "sequelize-typescript";
 import User from "./user.model";
 import Pet from "./pet.model";
 import Activity from "./activity.model";
 
-@Table({ timestamps:false, tableName: "user_pet_activities" })
+@Table({ timestamps: false, tableName: "user_pet_activities" })
 export default class UserPetActivity extends Model {
   @Column({})
   user_pet_activity_id!: number;
 
-  @ForeignKey (()=> User) // in case of null, task has not been assigned
+  @ForeignKey(() => User) // in case of null, task has not been assigned
   @Column({})
   user_id?: number;
 
-  @BelongsTo (()=>User)
+  @BelongsTo(() => User)
   user?: User;
 
-  @ForeignKey (()=> Pet)
+  @ForeignKey(() => Pet)
   @Column({})
   pet_id!: number;
 
-  @BelongsTo (()=>Pet)
+  @BelongsTo(() => Pet)
   pet!: Pet;
 
-  @ForeignKey (()=> Activity)
+  @ForeignKey(() => Activity)
   @Column({})
   activity_id!: number;
-  
-  @BelongsTo (()=> Activity)
+
+  @BelongsTo(() => Activity)
   activity!: Activity;
 
   @Column({})
@@ -39,7 +46,7 @@ export default class UserPetActivity extends Model {
   @Column({})
   end_time?: Date;
 
-  @Column({type: DataType.TEXT})
+  @Column({ type: DataType.TEXT })
   notes?: string;
 
   @Column({})


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Pet Relationship Tables](https://www.notion.so/uwblueprintexecs/Sprint-Board-4f2ffd2639ac41c4ad0f64818d84d5fa?p=c4bdff8ae86b4190abebd080bb13532a&pm=s)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added pet_behaviours table and user_pet_activities table
* scrapped pet_activities table for now, as the only use would be for automation of activities and that’s not a priority
* non-assigned tasks go into user_pet_activities where user column is null
* status in user_pet_activities is removed, not started/in progress/complete will be calculated from start and end timestamps

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
- tested tables, checked for null values + foreign keys
![image](https://github.com/uwblueprint/humane-society/assets/32817635/c714d144-a384-44b8-9eb2-25f6e6db170b)
![image](https://github.com/uwblueprint/humane-society/assets/32817635/382d27de-09da-4d2b-92be-9ef9d880ad08)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* changed Activities class name to Activity, is this ok/should this change be put somewhere else?
