### PR TITLE
S24/sayi/add user management endpoints

### DIFF
--- a/backend/typescript/middlewares/validators/userValidators.ts
+++ b/backend/typescript/middlewares/validators/userValidators.ts
@@ -63,16 +63,32 @@ export const updateUserDtoValidator = async (
   res: Response,
   next: NextFunction,
 ) => {
-  if (!validatePrimitive(req.body.firstName, "string")) {
+  if (
+    req.body.firstName !== undefined &&
+    req.body.firstName !== null &&
+    !validatePrimitive(req.body.firstName, "string")
+  ) {
     return res.status(400).send(getApiValidationError("firstName", "string"));
   }
-  if (!validatePrimitive(req.body.lastName, "string")) {
+  if (
+    req.body.lastName !== undefined &&
+    req.body.lastName !== null &&
+    !validatePrimitive(req.body.lastName, "string")
+  ) {
     return res.status(400).send(getApiValidationError("lastName", "string"));
   }
-  if (!validatePrimitive(req.body.email, "string")) {
+  if (
+    req.body.email !== undefined &&
+    req.body.email !== null &&
+    !validatePrimitive(req.body.email, "string")
+  ) {
     return res.status(400).send(getApiValidationError("email", "string"));
   }
-  if (!validatePrimitive(req.body.role, "string")) {
+  if (
+    req.body.role !== undefined &&
+    req.body.role !== null &&
+    !validatePrimitive(req.body.role, "string")
+  ) {
     return res.status(400).send(getApiValidationError("role", "string"));
   }
   if (

--- a/backend/typescript/rest/userRoutes.ts
+++ b/backend/typescript/rest/userRoutes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 
-import { isAuthorizedByRole } from "../middlewares/auth";
+import { getAccessToken, isAuthorizedByRole } from "../middlewares/auth";
 import {
   createUserDtoValidator,
   updateUserDtoValidator,
@@ -107,7 +107,7 @@ userRouter.post("/", createUserDtoValidator, async (req, res) => {
       lastName: req.body.lastName,
       email: req.body.email,
       role: req.body.role ?? Role.VOLUNTEER,
-      status: req.body.status ?? UserStatus.ACTIVE, // TODO: make this default to inactive once user registration flow is done
+      status: UserStatus.INVITED, // TODO: make this default to inactive once user registration flow is done
       skillLevel: req.body.skillLevel ?? null,
       canSeeAllLogs: req.body.canSeeAllLogs ?? null,
       canAssignUsersToTasks: req.body.canSeeAllUsers ?? null,
@@ -125,26 +125,65 @@ userRouter.post("/", createUserDtoValidator, async (req, res) => {
 
 /* Update the user with the specified userId */
 userRouter.put("/:userId", updateUserDtoValidator, async (req, res) => {
-  try {
-    const userId = Number(req.params.userId);
-    if (Number.isNaN(userId)) {
-      res.status(400).json({ error: "Invalid user ID" });
-    }
+  const userId = Number(req.params.userId);
+  if (Number.isNaN(userId)) {
+    res.status(400).json({ error: "Invalid user ID" });
+    return;
+  }
 
+  const accessToken = getAccessToken(req);
+  if (!accessToken) {
+    res.status(404).json({ error: "Access token not found" });
+    return;
+  }
+
+  try {
+    const isBehaviourist = await authService.isAuthorizedByRole(
+      accessToken,
+      new Set([Role.ANIMAL_BEHAVIOURIST]),
+    );
+    const behaviouristUpdatableSet = new Set(["skillLevel"]);
+    if (isBehaviourist) {
+      const deniedFieldSet = Object.keys(req.body).filter((field) => {
+        return !behaviouristUpdatableSet.has(field);
+      });
+      if (deniedFieldSet.length > 0) {
+        const deniedFieldsString = "Not authorized to update field(s): ".concat(
+          deniedFieldSet.join(", "),
+        );
+        res.status(403).json({ error: deniedFieldsString });
+        return;
+      }
+    }
+  } catch (error: unknown) {
+    if (error instanceof NotFoundError) {
+      res.status(400).json({ error: getErrorMessage(error) });
+    } else {
+      res.status(500).json({ error: getErrorMessage(error) });
+    }
+  }
+
+  try {
+    const user: UserDTO = await userService.getUserById(String(userId));
     const updatedUser = await userService.updateUserById(userId, {
-      firstName: req.body.firstName,
-      lastName: req.body.lastName,
-      email: req.body.email,
-      role: req.body.role,
-      status: req.body.status,
-      skillLevel: req.body.skillLevel ?? null,
-      canSeeAllLogs: req.body.canSeeAllLogs ?? null,
-      canAssignUsersToTasks: req.body.canSeeAllUsers ?? null,
-      phoneNumber: req.body.phoneNumber ?? null,
+      firstName: req.body.firstName ?? user.firstName,
+      lastName: req.body.lastName ?? user.lastName,
+      email: req.body.email ?? user.email,
+      role: req.body.role ?? user.role,
+      status: req.body.status ?? user.status,
+      skillLevel: req.body.skillLevel ?? user.skillLevel,
+      canSeeAllLogs: req.body.canSeeAllLogs ?? user.canSeeAllLogs,
+      canAssignUsersToTasks:
+        req.body.canAssignUsersToTasks ?? user.canAssignUsersToTasks,
+      phoneNumber: req.body.phoneNumber ?? user.phoneNumber,
     });
     res.status(200).json(updatedUser);
   } catch (error: unknown) {
-    res.status(500).json({ error: getErrorMessage(error) });
+    if (error instanceof NotFoundError) {
+      res.status(400).json({ error: getErrorMessage(error) });
+    } else {
+      res.status(500).json({ error: getErrorMessage(error) });
+    }
   }
 });
 

--- a/backend/typescript/rest/userRoutes.ts
+++ b/backend/typescript/rest/userRoutes.ts
@@ -107,7 +107,7 @@ userRouter.post("/", createUserDtoValidator, async (req, res) => {
       lastName: req.body.lastName,
       email: req.body.email,
       role: req.body.role ?? Role.VOLUNTEER,
-      status: UserStatus.INVITED, // TODO: make this default to inactive once user registration flow is done
+      status: UserStatus.INVITED,
       skillLevel: req.body.skillLevel ?? null,
       canSeeAllLogs: req.body.canSeeAllLogs ?? null,
       canAssignUsersToTasks: req.body.canSeeAllUsers ?? null,

--- a/backend/typescript/rest/userRoutes.ts
+++ b/backend/typescript/rest/userRoutes.ts
@@ -62,6 +62,8 @@ userRouter.get("/", async (req, res) => {
       res
         .status(400)
         .json({ error: "userId query parameter must be a string." });
+    } else if (Number.isNaN(Number(userId))) {
+      res.status(400).json({ error: "Invalid user ID" });
     } else {
       try {
         const user = await userService.getUserById(userId);
@@ -87,7 +89,11 @@ userRouter.get("/", async (req, res) => {
         const user = await userService.getUserByEmail(email);
         res.status(200).json(user);
       } catch (error: unknown) {
-        res.status(500).json({ error: getErrorMessage(error) });
+        if (error instanceof NotFoundError) {
+          res.status(404).send(getErrorMessage(error));
+        } else {
+          res.status(500).json({ error: getErrorMessage(error) });
+        }
       }
     }
   }

--- a/backend/typescript/services/implementations/userService.ts
+++ b/backend/typescript/services/implementations/userService.ts
@@ -240,6 +240,7 @@ class UserService implements IUserService {
         {
           first_name: user.firstName,
           last_name: user.lastName,
+          email: user.email,
           role: user.role,
           status: user.status,
           skill_level: user.skillLevel,
@@ -274,6 +275,7 @@ class UserService implements IUserService {
             {
               first_name: oldUser.first_name,
               last_name: oldUser.last_name,
+              email: oldUser.email,
               role: oldUser.role,
               status: oldUser.status,
               skill_level: oldUser.skill_level,

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -25,7 +25,7 @@ export type UserDTO = {
 
 export type CreateUserDTO = Omit<UserDTO, "id"> & { password: string };
 
-export type UpdateUserDTO = Partial<Omit<UserDTO, "id">>;
+export type UpdateUserDTO = Omit<UserDTO, "id">;
 
 export type RegisterUserDTO = Omit<CreateUserDTO, "role">;
 

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -25,7 +25,7 @@ export type UserDTO = {
 
 export type CreateUserDTO = Omit<UserDTO, "id"> & { password: string };
 
-export type UpdateUserDTO = Omit<UserDTO, "id">;
+export type UpdateUserDTO = Partial<Omit<UserDTO, "id">>;
 
 export type RegisterUserDTO = Omit<CreateUserDTO, "role">;
 


### PR DESCRIPTION
## Notion ticket link
<!-- https://www.notion.so/uwblueprintexecs/Sprint-Board-4f2ffd2639ac41c4ad0f64818d84d5fa?p=74724f68bf154da28e3f16ae90202ff1&pm=s -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Changed UpdateUserDTO/UpdateUserDtoValidator so that users can update a user without providing every field
* If a behaviourist tries to update a user and they update a value that they don't have access to, entire request is invalidated


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
GET
1. No queries (get all users)
<img width="1249" alt="UME - GET - all users" src="https://github.com/user-attachments/assets/f9074787-cb98-4e0c-8a7a-b54b12e142cc">

2. Query with both userId & email
<img width="1249" alt="UME - GET - email and userId query" src="https://github.com/user-attachments/assets/4332dbb5-5ac0-4b49-aa68-92f4422fab6b">

3. Invalid userId
<img width="1239" alt="UME - GET - invalid userId" src="https://github.com/user-attachments/assets/7c4f80f5-0f7b-4b8b-a3ce-0fe717ddc4f8">

4. UserId not in database
<img width="1249" alt="UME - GET - nonexisting userid" src="https://github.com/user-attachments/assets/e3e10b62-329f-4a30-a0e3-0493721a748e">

5. Get with userId (successful)
<img width="1249" alt="UME - GET by userid" src="https://github.com/user-attachments/assets/b331df0d-57ea-4344-a75f-c6e3140ce3a9">

6. Invalid email
<img width="1249" alt="UME - GET - invalid email" src="https://github.com/user-attachments/assets/e7d0f9dc-4ba7-4e57-8444-cc75dc05ff23">

7. Email not in database
<img width="1239" alt="UME - DELETE - nonexisting email" src="https://github.com/user-attachments/assets/e314a4f7-6876-444d-aa78-3125ca1455f4">

8. Get with email (successful)
<img width="1249" alt="UME - GET by email" src="https://github.com/user-attachments/assets/f73fc745-9f51-4d82-beb2-0f4c650d46cb">


PUT:
1. (Behaviourist) userId not in database (similarly, test invalid userId)
<img width="1249" alt="UME - AM - userId not found" src="https://github.com/user-attachments/assets/0c10c080-4dff-474e-950c-bed3728f80bd">

2. (Behaviourist) Update only invalid fields
<img width="1249" alt="UME - AM - Update only invalid fields" src="https://github.com/user-attachments/assets/250fa96d-1506-4b2b-8f2d-cc6f35712681">

3. (Behaviourist) Update invalid & valid fields
<img width="1249" alt="UME - AM - Update a few valid:invalid fields" src="https://github.com/user-attachments/assets/b19c51d2-4500-4a09-afc3-f3e728795c39">

4. (Behaviourist) Update valid fields
<img width="1249" alt="UME - AM - Successful Update" src="https://github.com/user-attachments/assets/566a02bc-ac76-4d57-926f-f61bce01a6df">

5. (Admin) Update all fields
<img width="1249" alt="UME - Admin - Success" src="https://github.com/user-attachments/assets/4de2cc2a-a4e5-4846-a7b3-db5d3840a354">


DELETE:
1. Query with both userId & email
<img width="1239" alt="UME - DELETE - both params" src="https://github.com/user-attachments/assets/0398daf9-6cff-43f5-8aa9-da4caf618de1">

2. Query without parameters
<img width="1239" alt="UME - DELETE - no params" src="https://github.com/user-attachments/assets/58618bec-cead-426a-ae57-f2d71ddf4071">

3. Invalid userId
<img width="1239" alt="UME - DELETE - Invalid userid" src="https://github.com/user-attachments/assets/d9345807-6092-4219-85f0-6d1dd4abd2aa">

4. userId not in database
<img width="1239" alt="UME - DELETE - nonexisting userid" src="https://github.com/user-attachments/assets/61951193-e989-4fd8-bd01-3a9f047590e3">

5. Delete user with "Active" status by userId/email
<img width="1239" alt="UME - DELETE - active by userid" src="https://github.com/user-attachments/assets/77da6146-4ac2-4276-a790-3a1d2726ae9c">

6. Delete Animal Behaviourist with "Inactive" status by userId
<img width="1239" alt="UME - DELETE - inactive behaviourist by email" src="https://github.com/user-attachments/assets/ac8cf179-a807-4836-99b8-d62503bcec3b">

6. Invalid email
<img width="1239" alt="UME - DELETE - invalid email" src="https://github.com/user-attachments/assets/739b0541-7dab-4422-9e2e-68234bbd3fe2">

7. Email not in database
<img width="1239" alt="UME - DELETE - nonexisting email" src="https://github.com/user-attachments/assets/286bfa06-dddb-4380-89ea-3dee94da5f09">

8. Delete volunteer with "Invited" status (by email)
<img width="1239" alt="UME - DELETE - invited volunteer by id" src="https://github.com/user-attachments/assets/ab964e94-0187-4d43-8fb9-1546ab50509b">

9. Delete as a Behaviourist
<img width="1239" alt="UME - DELETE - delete as behaviourist" src="https://github.com/user-attachments/assets/e72a3bc7-b3c3-456c-8fd9-4bd734aecda2">


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Refactored try catch statements in PUT 
* Set filtering for PUT
* Querying with a non-existent email doesn't return a NotFoundError (add this to emailService?)
* Querying with userId=10. gets through since Number(10.) returns 10, doesn't cause any problems, only visible when returning "userId 10. not found in database" (still checks database for userId 10 here)

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
