### PR TITLE
F24/justin/add user management and admin pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,9 +28,10 @@ import EditTeamInfoPage from "./components/pages/EditTeamPage";
 import HooksDemo from "./components/pages/HooksDemo";
 import NotificationsPage from "./components/pages/NotificationsPage";
 import ProfilePage from "./components/pages/ProfilePage";
+import UserManagementPage from "./components/pages/UserManagementPage";
+import AdminPage from "./components/pages/AdminPage";
 
 import { AuthenticatedUser } from "./types/AuthTypes";
-import UserManagementPage from "./components/pages/UserManagementPage";
 
 const App = (): React.ReactElement => {
   const currentUser: AuthenticatedUser = getLocalStorageObj<AuthenticatedUser>(
@@ -135,7 +136,7 @@ const App = (): React.ReactElement => {
               <PrivateRoute
                 exact
                 path={Routes.ADMIN_PAGE}
-                component={Default}
+                component={AdminPage}
                 allowedRoles={AuthConstants.ADMIN_AND_BEHAVIOURISTS}
               />
               <PrivateRoute

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import NotificationsPage from "./components/pages/NotificationsPage";
 import ProfilePage from "./components/pages/ProfilePage";
 
 import { AuthenticatedUser } from "./types/AuthTypes";
+import UserManagementPage from "./components/pages/UserManagementPage";
 
 const App = (): React.ReactElement => {
   const currentUser: AuthenticatedUser = getLocalStorageObj<AuthenticatedUser>(
@@ -130,6 +131,18 @@ const App = (): React.ReactElement => {
                 path={Routes.PROFILE_PAGE}
                 component={ProfilePage}
                 allowedRoles={AuthConstants.ALL_ROLES}
+              />
+              <PrivateRoute
+                exact
+                path={Routes.ADMIN_PAGE}
+                component={Default}
+                allowedRoles={AuthConstants.ADMIN_AND_BEHAVIOURISTS}
+              />
+              <PrivateRoute
+                exact
+                path={Routes.USER_MANAGEMENT_PAGE}
+                component={UserManagementPage}
+                allowedRoles={AuthConstants.ADMIN_AND_BEHAVIOURISTS}
               />
               <Route exact path="*" component={NotFound} />
             </Switch>

--- a/frontend/src/components/pages/AdminPage.tsx
+++ b/frontend/src/components/pages/AdminPage.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import MainPageButton from "../common/MainPageButton";
+
+const AdminPage = (): React.ReactElement => {
+  return (
+    <div style={{ textAlign: "center", width: "25%", margin: "0px auto" }}>
+      <h1>Admin Page</h1>
+      <MainPageButton />
+    </div>
+  );
+};
+
+export default AdminPage;

--- a/frontend/src/components/pages/UserManagementPage.tsx
+++ b/frontend/src/components/pages/UserManagementPage.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import MainPageButton from "../common/MainPageButton";
+
+const UserManagementPage = (): React.ReactElement => {
+  return (
+    <div style={{ textAlign: "center", width: "25%", margin: "0px auto" }}>
+      <h1>User Management</h1>
+      <MainPageButton />
+    </div>
+  );
+};
+
+export default UserManagementPage;

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -25,3 +25,7 @@ export const NOTIFICATIONS_PAGE = "/notifications";
 export const PROFILE_PAGE = "/profile";
 
 export const DEV_UTILITY_PAGE = "/dev-utility"; // TODO: This is only here for development purposes
+
+export const USER_MANAGEMENT_PAGE = "/admin/users";
+
+export const ADMIN_PAGE = "/admin";


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created a skeleton user management page that only admins and behaviourists can access. This can be found at the following route: admin/users

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Just test using roles as an admin or behavourist if you can go to the route: /admin/users


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Just focus on accessing using the different roles
## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
