### PR TITLE
Set UserStatus to Inactive on creation

### DIFF
--- a/backend/typescript/rest/userRoutes.ts
+++ b/backend/typescript/rest/userRoutes.ts
@@ -114,8 +114,6 @@ userRouter.post("/", createUserDtoValidator, async (req, res) => {
       phoneNumber: req.body.phoneNumber ?? null,
     });
 
-    // await authService.sendEmailVerificationLink(req.body.email);
-
     res.status(201).json(newUser);
   } catch (error: unknown) {
     res.status(500).json({ error: getErrorMessage(error) });

--- a/backend/typescript/services/implementations/userService.ts
+++ b/backend/typescript/services/implementations/userService.ts
@@ -186,7 +186,7 @@ class UserService implements IUserService {
           last_name: user.lastName,
           auth_id: firebaseUser.uid,
           role: user.role,
-          status: UserStatus.INVITED,
+          status: UserStatus.INACTIVE,
           email: firebaseUser.email ?? "",
           skill_level: user.skillLevel,
           can_see_all_logs: user.canSeeAllLogs,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Change UserStatus to Inactive instead of Invited when calling createUser


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
