### PR TITLE
W25/julia vibhor/activity management endpoints ii

### DIFF
--- a/backend/typescript/middlewares/validators/activityValidators.ts
+++ b/backend/typescript/middlewares/validators/activityValidators.ts
@@ -145,7 +145,7 @@ export const activityUserPatchValidator = async (
   if (!validatePrimitive(body.userId, "integer")) {
     return res.status(400).send(getApiValidationError("userId", "integer"));
   }
-  
+
   return next();
 };
 
@@ -157,9 +157,11 @@ export const activityScheduledTimePatchValidator = async (
   const { body } = req;
 
   if (!validateDate(body.scheduledStartTime)) {
-    return res.status(400).send(getApiValidationError("scheduledStartTime", "Date"));
+    return res
+      .status(400)
+      .send(getApiValidationError("scheduledStartTime", "Date"));
   }
-  
+
   return next();
 };
 
@@ -173,7 +175,7 @@ export const activityStartTimePatchValidator = async (
   if (!validateDate(body.startTime)) {
     return res.status(400).send(getApiValidationError("startTime", "Date"));
   }
-  
+
   return next();
 };
 
@@ -187,7 +189,7 @@ export const activityEndTimePatchValidator = async (
   if (!validateDate(body.endTime)) {
     return res.status(400).send(getApiValidationError("endTime", "Date"));
   }
-  
+
   return next();
 };
 
@@ -197,9 +199,7 @@ export const activityNotesPatchValidator = async (
   next: NextFunction,
 ) => {
   const { body } = req;
-  if (
-    !validatePrimitive(body.notes, "string")
-  ) {
+  if (!validatePrimitive(body.notes, "string")) {
     return res.status(400).send(getApiValidationError("notes", "string"));
   }
 

--- a/backend/typescript/middlewares/validators/activityValidators.ts
+++ b/backend/typescript/middlewares/validators/activityValidators.ts
@@ -134,3 +134,74 @@ export const activityUpdateDtoValidator = async (
 
   return next();
 };
+
+export const activityUserPatchValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const { body } = req;
+
+  if (!validatePrimitive(body.userId, "integer")) {
+    return res.status(400).send(getApiValidationError("userId", "integer"));
+  }
+  
+  return next();
+};
+
+export const activityScheduledTimePatchValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const { body } = req;
+
+  if (!validateDate(body.scheduledStartTime)) {
+    return res.status(400).send(getApiValidationError("scheduledStartTime", "Date"));
+  }
+  
+  return next();
+};
+
+export const activityStartTimePatchValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const { body } = req;
+
+  if (!validateDate(body.startTime)) {
+    return res.status(400).send(getApiValidationError("startTime", "Date"));
+  }
+  
+  return next();
+};
+
+export const activityEndTimePatchValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const { body } = req;
+
+  if (!validateDate(body.endTime)) {
+    return res.status(400).send(getApiValidationError("endTime", "Date"));
+  }
+  
+  return next();
+};
+
+export const activityNotesPatchValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const { body } = req;
+  if (
+    !validatePrimitive(body.notes, "string")
+  ) {
+    return res.status(400).send(getApiValidationError("notes", "string"));
+  }
+
+  return next();
+};

--- a/backend/typescript/rest/activityRoutes.ts
+++ b/backend/typescript/rest/activityRoutes.ts
@@ -167,7 +167,7 @@ activityRouter.patch(
     try {
       const { body } = req;
       const Activity = await activityService.scheduleActivity(id, {
-        time: body.scheduledStartTime
+        time: body.scheduledStartTime,
       });
       res.status(200).json(Activity);
     } catch (e: unknown) {
@@ -185,7 +185,7 @@ activityRouter.patch(
     try {
       const { body } = req;
       const Activity = await activityService.startActivity(id, {
-        time: body.startTime
+        time: body.startTime,
       });
       res.status(200).json(Activity);
     } catch (e: unknown) {
@@ -203,7 +203,7 @@ activityRouter.patch(
     try {
       const { body } = req;
       const Activity = await activityService.endActivity(id, {
-        time: body.endTime
+        time: body.endTime,
       });
       res.status(200).json(Activity);
     } catch (e: unknown) {
@@ -221,7 +221,7 @@ activityRouter.patch(
     try {
       const { body } = req;
       const Activity = await activityService.updateActivityNotes(id, {
-        notes: body.notes
+        notes: body.notes,
       });
       res.status(200).json(Activity);
     } catch (e: unknown) {

--- a/backend/typescript/services/implementations/activityService.ts
+++ b/backend/typescript/services/implementations/activityService.ts
@@ -3,6 +3,9 @@ import {
   IActivityService,
   ActivityRequestDTO,
   ActivityResponseDTO,
+  ActivityUserPatchDTO,
+  ActivityTimePatchDTO,
+  ActivityNotesPatchDTO,
 } from "../interfaces/activityService";
 import { getErrorMessage, NotFoundError } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
@@ -60,6 +63,59 @@ class ActivityService implements IActivityService {
     }
   }
 
+  async getPetActivities(pet_id: string): Promise<Array<ActivityResponseDTO>> {
+    try {
+      const activities: Array<PgActivity> = await PgActivity.findAll({
+        where: {
+          pet_id: pet_id,
+        },
+        raw: true,
+      });
+      return activities.map((activity) => ({
+        id: activity.id,
+        userId: activity.user_id,
+        petId: activity.pet_id,
+        activityTypeId: activity.activity_type_id,
+        scheduledStartTime: activity.scheduled_start_time,
+        startTime: activity.start_time,
+        endTime: activity.end_time,
+        notes: activity.notes,
+      }));
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to get activites. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  async getUserActivities(user_id: string): Promise<Array<ActivityResponseDTO>> {
+    try {
+      const activities: Array<PgActivity> = await PgActivity.findAll({
+        where: {
+          user_id: user_id,
+        },
+        raw: true,
+      });
+      return activities.map((activity) => ({
+        id: activity.id,
+        userId: activity.user_id,
+        petId: activity.pet_id,
+        activityTypeId: activity.activity_type_id,
+        scheduledStartTime: activity.scheduled_start_time,
+        startTime: activity.start_time,
+        endTime: activity.end_time,
+        notes: activity.notes,
+      }));
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to get activites. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+
   async createActivity(
     activity: ActivityRequestDTO,
   ): Promise<ActivityResponseDTO> {
@@ -108,6 +164,188 @@ class ActivityService implements IActivityService {
           start_time: activity.startTime,
           end_time: activity.endTime,
           notes: activity.notes,
+        },
+        { where: { id }, returning: true },
+      );
+
+      if (!updateResult[0]) {
+        throw new NotFoundError(`Activity id ${id} not found`);
+      }
+      [, [resultingActivity]] = updateResult;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to update activity. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+    return {
+      id: resultingActivity.id,
+      userId: resultingActivity.user_id,
+      petId: resultingActivity.pet_id,
+      activityTypeId: resultingActivity.activity_type_id,
+      scheduledStartTime: resultingActivity.scheduled_start_time,
+      startTime: resultingActivity.start_time,
+      endTime: resultingActivity.end_time,
+      notes: resultingActivity.notes,
+    };
+  }
+
+  async assignUser(
+    id: string,
+    user: ActivityUserPatchDTO
+  ): Promise<ActivityResponseDTO | null> {
+    let resultingActivity: PgActivity | null;
+    let updateResult: [number, PgActivity[]] | null;
+    try {
+      updateResult = await PgActivity.update(
+        {
+          user_id: user.userId,
+        },
+        { where: { id }, returning: true },
+      );
+
+      if (!updateResult[0]) {
+        throw new NotFoundError(`Activity id ${id} not found`);
+      }
+      [, [resultingActivity]] = updateResult;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to update activity. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+    return {
+      id: resultingActivity.id,
+      userId: resultingActivity.user_id,
+      petId: resultingActivity.pet_id,
+      activityTypeId: resultingActivity.activity_type_id,
+      scheduledStartTime: resultingActivity.scheduled_start_time,
+      startTime: resultingActivity.start_time,
+      endTime: resultingActivity.end_time,
+      notes: resultingActivity.notes,
+    };
+  }
+
+  async scheduleActivity(
+    id: string,
+    schedule: ActivityTimePatchDTO
+  ): Promise<ActivityResponseDTO | null> {
+    let resultingActivity: PgActivity | null;
+    let updateResult: [number, PgActivity[]] | null;
+    try {
+      updateResult = await PgActivity.update(
+        {
+          scheduled_start_time: schedule.time,
+        },
+        { where: { id }, returning: true },
+      );
+
+      if (!updateResult[0]) {
+        throw new NotFoundError(`Activity id ${id} not found`);
+      }
+      [, [resultingActivity]] = updateResult;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to update activity. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+    return {
+      id: resultingActivity.id,
+      userId: resultingActivity.user_id,
+      petId: resultingActivity.pet_id,
+      activityTypeId: resultingActivity.activity_type_id,
+      scheduledStartTime: resultingActivity.scheduled_start_time,
+      startTime: resultingActivity.start_time,
+      endTime: resultingActivity.end_time,
+      notes: resultingActivity.notes,
+    };
+  }
+    
+      
+  async startActivity(
+      id: string,
+      startTime: ActivityTimePatchDTO
+    ): Promise<ActivityResponseDTO | null> {
+      let resultingActivity: PgActivity | null;
+      let updateResult: [number, PgActivity[]] | null;
+      try {
+        updateResult = await PgActivity.update(
+          {
+            start_time: startTime.time,
+          },
+          { where: { id }, returning: true },
+        );
+  
+        if (!updateResult[0]) {
+          throw new NotFoundError(`Activity id ${id} not found`);
+        }
+        [, [resultingActivity]] = updateResult;
+      } catch (error: unknown) {
+        Logger.error(
+          `Failed to update activity. Reason = ${getErrorMessage(error)}`,
+        );
+        throw error;
+      }
+      return {
+        id: resultingActivity.id,
+        userId: resultingActivity.user_id,
+        petId: resultingActivity.pet_id,
+        activityTypeId: resultingActivity.activity_type_id,
+        scheduledStartTime: resultingActivity.scheduled_start_time,
+        startTime: resultingActivity.start_time,
+        endTime: resultingActivity.end_time,
+        notes: resultingActivity.notes,
+      };
+    }
+    
+  async endActivity(
+      id: string,
+      endTime: ActivityTimePatchDTO
+    ): Promise<ActivityResponseDTO | null> {
+      let resultingActivity: PgActivity | null;
+      let updateResult: [number, PgActivity[]] | null;
+      try {
+        updateResult = await PgActivity.update(
+          {
+            end_time: endTime.time,
+          },
+          { where: { id }, returning: true },
+        );
+  
+        if (!updateResult[0]) {
+          throw new NotFoundError(`Activity id ${id} not found`);
+        }
+        [, [resultingActivity]] = updateResult;
+      } catch (error: unknown) {
+        Logger.error(
+          `Failed to update activity. Reason = ${getErrorMessage(error)}`,
+        );
+        throw error;
+      }
+      return {
+        id: resultingActivity.id,
+        userId: resultingActivity.user_id,
+        petId: resultingActivity.pet_id,
+        activityTypeId: resultingActivity.activity_type_id,
+        scheduledStartTime: resultingActivity.scheduled_start_time,
+        startTime: resultingActivity.start_time,
+        endTime: resultingActivity.end_time,
+        notes: resultingActivity.notes,
+      };
+    }
+    
+      
+  async updateActivityNotes(
+    id: string,
+    notes: ActivityNotesPatchDTO
+  ): Promise<ActivityResponseDTO | null> {
+    let resultingActivity: PgActivity | null;
+    let updateResult: [number, PgActivity[]] | null;
+    try {
+      updateResult = await PgActivity.update(
+        {
+          notes: notes.notes,
         },
         { where: { id }, returning: true },
       );

--- a/backend/typescript/services/implementations/activityService.ts
+++ b/backend/typescript/services/implementations/activityService.ts
@@ -67,10 +67,13 @@ class ActivityService implements IActivityService {
     try {
       const activities: Array<PgActivity> = await PgActivity.findAll({
         where: {
-          pet_id: pet_id,
+          pet_id,
         },
         raw: true,
       });
+      if (!activities[0]) {
+        throw new NotFoundError(`No activities for pet id ${pet_id}`);
+      }
       return activities.map((activity) => ({
         id: activity.id,
         userId: activity.user_id,
@@ -89,14 +92,19 @@ class ActivityService implements IActivityService {
     }
   }
 
-  async getUserActivities(user_id: string): Promise<Array<ActivityResponseDTO>> {
+  async getUserActivities(
+    user_id: string,
+  ): Promise<Array<ActivityResponseDTO>> {
     try {
       const activities: Array<PgActivity> = await PgActivity.findAll({
         where: {
-          user_id: user_id,
+          user_id,
         },
         raw: true,
       });
+      if (!activities[0]) {
+        throw new NotFoundError(`No activities for user id ${user_id}`);
+      }
       return activities.map((activity) => ({
         id: activity.id,
         userId: activity.user_id,
@@ -114,7 +122,6 @@ class ActivityService implements IActivityService {
       throw error;
     }
   }
-
 
   async createActivity(
     activity: ActivityRequestDTO,
@@ -192,7 +199,7 @@ class ActivityService implements IActivityService {
 
   async assignUser(
     id: string,
-    user: ActivityUserPatchDTO
+    user: ActivityUserPatchDTO,
   ): Promise<ActivityResponseDTO | null> {
     let resultingActivity: PgActivity | null;
     let updateResult: [number, PgActivity[]] | null;
@@ -228,7 +235,7 @@ class ActivityService implements IActivityService {
 
   async scheduleActivity(
     id: string,
-    schedule: ActivityTimePatchDTO
+    schedule: ActivityTimePatchDTO,
   ): Promise<ActivityResponseDTO | null> {
     let resultingActivity: PgActivity | null;
     let updateResult: [number, PgActivity[]] | null;
@@ -261,84 +268,82 @@ class ActivityService implements IActivityService {
       notes: resultingActivity.notes,
     };
   }
-    
-      
+
   async startActivity(
-      id: string,
-      startTime: ActivityTimePatchDTO
-    ): Promise<ActivityResponseDTO | null> {
-      let resultingActivity: PgActivity | null;
-      let updateResult: [number, PgActivity[]] | null;
-      try {
-        updateResult = await PgActivity.update(
-          {
-            start_time: startTime.time,
-          },
-          { where: { id }, returning: true },
-        );
-  
-        if (!updateResult[0]) {
-          throw new NotFoundError(`Activity id ${id} not found`);
-        }
-        [, [resultingActivity]] = updateResult;
-      } catch (error: unknown) {
-        Logger.error(
-          `Failed to update activity. Reason = ${getErrorMessage(error)}`,
-        );
-        throw error;
+    id: string,
+    startTime: ActivityTimePatchDTO,
+  ): Promise<ActivityResponseDTO | null> {
+    let resultingActivity: PgActivity | null;
+    let updateResult: [number, PgActivity[]] | null;
+    try {
+      updateResult = await PgActivity.update(
+        {
+          start_time: startTime.time,
+        },
+        { where: { id }, returning: true },
+      );
+
+      if (!updateResult[0]) {
+        throw new NotFoundError(`Activity id ${id} not found`);
       }
-      return {
-        id: resultingActivity.id,
-        userId: resultingActivity.user_id,
-        petId: resultingActivity.pet_id,
-        activityTypeId: resultingActivity.activity_type_id,
-        scheduledStartTime: resultingActivity.scheduled_start_time,
-        startTime: resultingActivity.start_time,
-        endTime: resultingActivity.end_time,
-        notes: resultingActivity.notes,
-      };
+      [, [resultingActivity]] = updateResult;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to update activity. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
     }
-    
+    return {
+      id: resultingActivity.id,
+      userId: resultingActivity.user_id,
+      petId: resultingActivity.pet_id,
+      activityTypeId: resultingActivity.activity_type_id,
+      scheduledStartTime: resultingActivity.scheduled_start_time,
+      startTime: resultingActivity.start_time,
+      endTime: resultingActivity.end_time,
+      notes: resultingActivity.notes,
+    };
+  }
+
   async endActivity(
-      id: string,
-      endTime: ActivityTimePatchDTO
-    ): Promise<ActivityResponseDTO | null> {
-      let resultingActivity: PgActivity | null;
-      let updateResult: [number, PgActivity[]] | null;
-      try {
-        updateResult = await PgActivity.update(
-          {
-            end_time: endTime.time,
-          },
-          { where: { id }, returning: true },
-        );
-  
-        if (!updateResult[0]) {
-          throw new NotFoundError(`Activity id ${id} not found`);
-        }
-        [, [resultingActivity]] = updateResult;
-      } catch (error: unknown) {
-        Logger.error(
-          `Failed to update activity. Reason = ${getErrorMessage(error)}`,
-        );
-        throw error;
+    id: string,
+    endTime: ActivityTimePatchDTO,
+  ): Promise<ActivityResponseDTO | null> {
+    let resultingActivity: PgActivity | null;
+    let updateResult: [number, PgActivity[]] | null;
+    try {
+      updateResult = await PgActivity.update(
+        {
+          end_time: endTime.time,
+        },
+        { where: { id }, returning: true },
+      );
+
+      if (!updateResult[0]) {
+        throw new NotFoundError(`Activity id ${id} not found`);
       }
-      return {
-        id: resultingActivity.id,
-        userId: resultingActivity.user_id,
-        petId: resultingActivity.pet_id,
-        activityTypeId: resultingActivity.activity_type_id,
-        scheduledStartTime: resultingActivity.scheduled_start_time,
-        startTime: resultingActivity.start_time,
-        endTime: resultingActivity.end_time,
-        notes: resultingActivity.notes,
-      };
+      [, [resultingActivity]] = updateResult;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to update activity. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
     }
-    
-      
+    return {
+      id: resultingActivity.id,
+      userId: resultingActivity.user_id,
+      petId: resultingActivity.pet_id,
+      activityTypeId: resultingActivity.activity_type_id,
+      scheduledStartTime: resultingActivity.scheduled_start_time,
+      startTime: resultingActivity.start_time,
+      endTime: resultingActivity.end_time,
+      notes: resultingActivity.notes,
+    };
+  }
+
   async updateActivityNotes(
     id: string,
-    notes: ActivityNotesPatchDTO
+    notes: ActivityNotesPatchDTO,
   ): Promise<ActivityResponseDTO | null> {
     let resultingActivity: PgActivity | null;
     let updateResult: [number, PgActivity[]] | null;

--- a/backend/typescript/services/interfaces/activityService.ts
+++ b/backend/typescript/services/interfaces/activityService.ts
@@ -103,7 +103,7 @@ export interface IActivityService {
    * @returns the updated Activity
    * @throws Error if update fails
    */
-    scheduleActivity(
+  scheduleActivity(
       id: string,
       schedule: ActivityTimePatchDTO
     ): Promise<ActivityResponseDTO | null>;

--- a/backend/typescript/services/interfaces/activityService.ts
+++ b/backend/typescript/services/interfaces/activityService.ts
@@ -56,7 +56,7 @@ export interface IActivityService {
    */
   getPetActivities(pet_id: string): Promise<Array<ActivityResponseDTO>>;
 
-   /**
+  /**
    * retrieve all Activities for a specific user
    * @param user_id user id
    * @returns returns array of Activities
@@ -93,7 +93,7 @@ export interface IActivityService {
    */
   assignUser(
     id: string,
-    user: ActivityUserPatchDTO
+    user: ActivityUserPatchDTO,
   ): Promise<ActivityResponseDTO | null>;
 
   /**
@@ -104,9 +104,9 @@ export interface IActivityService {
    * @throws Error if update fails
    */
   scheduleActivity(
-      id: string,
-      schedule: ActivityTimePatchDTO
-    ): Promise<ActivityResponseDTO | null>;
+    id: string,
+    schedule: ActivityTimePatchDTO,
+  ): Promise<ActivityResponseDTO | null>;
 
   /**
    * starts an activity by adding a start time
@@ -117,7 +117,7 @@ export interface IActivityService {
    */
   startActivity(
     id: string,
-    startTime: ActivityTimePatchDTO
+    startTime: ActivityTimePatchDTO,
   ): Promise<ActivityResponseDTO | null>;
 
   /**
@@ -129,7 +129,7 @@ export interface IActivityService {
    */
   endActivity(
     id: string,
-    endTime: ActivityTimePatchDTO
+    endTime: ActivityTimePatchDTO,
   ): Promise<ActivityResponseDTO | null>;
 
   /**
@@ -141,7 +141,7 @@ export interface IActivityService {
    */
   updateActivityNotes(
     id: string,
-    notes: ActivityNotesPatchDTO
+    notes: ActivityNotesPatchDTO,
   ): Promise<ActivityResponseDTO | null>;
 
   /**

--- a/backend/typescript/services/interfaces/activityService.ts
+++ b/backend/typescript/services/interfaces/activityService.ts
@@ -19,6 +19,18 @@ export interface ActivityResponseDTO {
   notes?: string;
 }
 
+export interface ActivityUserPatchDTO {
+  userId: number;
+}
+
+export interface ActivityTimePatchDTO {
+  time: Date;
+}
+
+export interface ActivityNotesPatchDTO {
+  notes: string;
+}
+
 export interface IActivityService {
   /**
    * retrieve the Activity with the given id
@@ -35,6 +47,22 @@ export interface IActivityService {
    * @throws Error if retrieval fails
    */
   getActivities(): Promise<Array<ActivityResponseDTO>>;
+
+  /**
+   * retrieve all Activities for a specific pet
+   * @param pet_id pet id
+   * @returns returns array of Activities
+   * @throws Error if retrieval fails
+   */
+  getPetActivities(pet_id: string): Promise<Array<ActivityResponseDTO>>;
+
+   /**
+   * retrieve all Activities for a specific user
+   * @param user_id user id
+   * @returns returns array of Activities
+   * @throws Error if retrieval fails
+   */
+  getUserActivities(user_id: string): Promise<Array<ActivityResponseDTO>>;
 
   /**
    * create a Activity with the fields given in the DTO, return created Activity
@@ -54,6 +82,66 @@ export interface IActivityService {
   updateActivity(
     id: string,
     Activity: ActivityRequestDTO,
+  ): Promise<ActivityResponseDTO | null>;
+
+  /**
+   * assign a user to an activity, or update the user assigned to an activity, return updated Activity
+   * @param id Activity id
+   * @param user Assigned user
+   * @returns the updated Activity
+   * @throws Error if update fails
+   */
+  assignUser(
+    id: string,
+    user: ActivityUserPatchDTO
+  ): Promise<ActivityResponseDTO | null>;
+
+  /**
+   * schedules an activity with a start time or updates an existing schedule
+   * @param id Activity id
+   * @param schedule the scheduled start time
+   * @returns the updated Activity
+   * @throws Error if update fails
+   */
+    scheduleActivity(
+      id: string,
+      schedule: ActivityTimePatchDTO
+    ): Promise<ActivityResponseDTO | null>;
+
+  /**
+   * starts an activity by adding a start time
+   * @param id Activity id
+   * @param startTime the scheduled start time
+   * @returns the updated Activity
+   * @throws Error if update fails
+   */
+  startActivity(
+    id: string,
+    startTime: ActivityTimePatchDTO
+  ): Promise<ActivityResponseDTO | null>;
+
+  /**
+   * ends an activity by adding a end time
+   * @param id Activity id
+   * @param endTime the scheduled end time
+   * @returns the updated Activity
+   * @throws Error if update fails
+   */
+  endActivity(
+    id: string,
+    endTime: ActivityTimePatchDTO
+  ): Promise<ActivityResponseDTO | null>;
+
+  /**
+   * updates notes for an activity
+   * @param id Activity id
+   * @param notes the new notes
+   * @returns the updated Activity
+   * @throws Error if update fails
+   */
+  updateActivityNotes(
+    id: string,
+    notes: ActivityNotesPatchDTO
   ): Promise<ActivityResponseDTO | null>;
 
   /**


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Activity Management Endpoints II](https://www.notion.so/uwblueprintexecs/Activity-Management-Endpoints-II-11a10f3fb1dc807aa9c5d416915051d0?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added more activity management endpoints


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. `GET /activities/pet/<pet_id>` - Retrieves all activities for a specific pet.
![image](https://github.com/user-attachments/assets/1adb58a0-8d89-4484-a5fe-897a65669678)

Pet id does not exist/no activities for a given pet id
![image](https://github.com/user-attachments/assets/be9f1bdc-6df9-4a5f-bcdf-dd4d89b12f14)

Id not an integer
![image](https://github.com/user-attachments/assets/23f8089b-fd9a-43ca-8cf1-6749d2b562be)

2. `GET /activities/user/<user_id>` - Retrieves all activities for a specific user.
![image](https://github.com/user-attachments/assets/34f8c1da-61b3-4d20-9f21-48306a339bb5)
![image](https://github.com/user-attachments/assets/4aa7aaa4-5c7f-48b4-9cca-e1ad4d8cab75)

3. `PATCH /activities/<id>/assign-user` - Assigns a user to an activity. Can also update the user assigned to an activity.
Assign user
![image](https://github.com/user-attachments/assets/4072d5c7-72de-4c7e-8098-66058cf9bb23)

Update user
![image](https://github.com/user-attachments/assets/b18d0791-d75e-444b-a2f8-f6319e9a808e)

Invalid user
![image](https://github.com/user-attachments/assets/a8da1979-4ec2-4516-b8f3-90ee94f23a58)

Invalid activity
![image](https://github.com/user-attachments/assets/126eab9a-6788-45fc-ae47-b23c052a6aec)
![image](https://github.com/user-attachments/assets/68c575d6-0855-4da3-abab-5757b33aac12)

userId not provided
![image](https://github.com/user-attachments/assets/63aae249-209a-40b1-a25b-cae4ab1ab118)

4. `PATCH /activities/<id>/schedule` - Schedules an activity with a start time or updates an existing schedule.
![image](https://github.com/user-attachments/assets/444d1c1e-80b8-4793-abf1-2e8c0b23e80b)

Invalid date
![image](https://github.com/user-attachments/assets/97a7f1e1-7ef3-42a7-a3ba-fc5d4b68b46b)

no scheduledStartTime field
![image](https://github.com/user-attachments/assets/2e80ff05-2404-4fe5-9206-7d28d80ddbd6)

5. `PATCH /activities/<id>/start` - Marks an activity as started by adding a start time.
![image](https://github.com/user-attachments/assets/e51f25a9-c8fe-4041-bbcf-ca2286dca70b)

6. `PATCH /activities/<id>/end` - Marks an activity as ended by adding an end time.
![image](https://github.com/user-attachments/assets/0c42461d-fa16-4958-bf7f-527b986d843b)

7. `PATCH /activities/<id>/notes` - Adds or updates notes for an activity.
![image](https://github.com/user-attachments/assets/641b9730-8278-4b24-af42-43f47630f5f6)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Are the error messages okay?
* For the patch endpoints it doesn't throw an error if you provide extra fields as long as the required field is there. Should we be stricter?


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
