### PR TITLE
add category + instruction columns to activity type

### DIFF
--- a/backend/typescript/migrations/2025.02.21T02.19.04.add-category-instruction-to-activity-type.ts
+++ b/backend/typescript/migrations/2025.02.21T02.19.04.add-category-instruction-to-activity-type.ts
@@ -1,0 +1,26 @@
+import { DataType } from "sequelize-typescript";
+import { Migration } from "../umzug";
+import { Category } from "../types";
+
+const TABLE_NAME = "activity_types";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().addColumn(TABLE_NAME, "category", {
+    type: DataType.ENUM(...Object.values(Category)),
+    allowNull: false,
+    defaultValue: Category.MISC,
+  });
+  await sequelize.getQueryInterface().addColumn(TABLE_NAME, "instruction", {
+    type: DataType.TEXT,
+    allowNull: true,
+  });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().removeColumn(TABLE_NAME, "category");
+  await sequelize.getQueryInterface().removeColumn(TABLE_NAME, "instruction");
+  // delete category enum, otherwise causes issues with migrating up, down, then up
+  await sequelize
+    .getQueryInterface()
+    .sequelize.query('DROP TYPE IF EXISTS "enum_activity_types_category";');
+};

--- a/backend/typescript/models/activityType.model.ts
+++ b/backend/typescript/models/activityType.model.ts
@@ -1,7 +1,17 @@
-import { Column, Model, Table } from "sequelize-typescript";
+import { Column, Model, Table, DataType } from "sequelize-typescript";
+import { Category } from "../types";
 
 @Table({ timestamps: false, tableName: "activity_types" })
 export default class ActivityType extends Model {
-  @Column
+  @Column({ type: DataType.STRING, allowNull: false })
   activity_name!: string;
+
+  @Column({
+    type: DataType.ENUM(...Object.values(Category)),
+    allowNull: false,
+  })
+  category!: Category;
+
+  @Column({ type: DataType.TEXT, allowNull: true })
+  instruction?: string;
 }

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -61,6 +61,15 @@ export enum UserStatus {
   INACTIVE = "Inactive",
 }
 
+export enum Category {
+  GAMES = "Games",
+  HUSBANDRY = "Husbandry",
+  PEN_TIME = "Pen time",
+  TRAINING = "Training",
+  WALK = "Walk",
+  MISC = "Misc.",
+}
+
 export type NodemailerConfig = {
   service: "gmail";
   auth: {

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -64,7 +64,7 @@ export enum UserStatus {
 export enum Category {
   GAMES = "Games",
   HUSBANDRY = "Husbandry",
-  PEN_TIME = "Pen time",
+  PEN_TIME = "Pen Time",
   TRAINING = "Training",
   WALK = "Walk",
   MISC = "Misc.",


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Update Activity Type model to support categories and instruction](https://www.notion.so/uwblueprintexecs/Sprint-Board-4f2ffd2639ac41c4ad0f64818d84d5fa?p=1a010f3fb1dc80cdb723eb4a82b5431e&pm=s)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* add mandatory category field defaulting to misc.
* add optional instruction field of type text 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. node migrate up/down/up
2. should be a required 'category' column that can take on the following values:
    - Games
    - Husbandry
    - Pen time
    - Training
    - Walk
    - Misc.
3. should be an optional 'instruction' column that can take a multiline string

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* had to delete enum type in the node migrate down so you can migrate up, down, then up again?


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
