### PR TITLE
W25/sayi/add auth endpoints

### DIFF
--- a/backend/typescript/middlewares/validators/authValidators.ts
+++ b/backend/typescript/middlewares/validators/authValidators.ts
@@ -75,32 +75,3 @@ export const inviteUserDtoValidator = async (
   }
   return next();
 };
-
-export const updateOwnUserDtoValidator = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => {
-  if (
-    req.body.firstName !== undefined &&
-    req.body.firstName !== null &&
-    !validatePrimitive(req.body.firstName, "string")
-  ) {
-    return res.status(400).send(getApiValidationError("firstName", "string"));
-  }
-  if (
-    req.body.lastName !== undefined &&
-    req.body.lastName !== null &&
-    !validatePrimitive(req.body.lastName, "string")
-  ) {
-    return res.status(400).send(getApiValidationError("lastName", "string"));
-  }
-  if (
-    req.body.phoneNumber !== undefined &&
-    req.body.phoneNumber !== null &&
-    !validatePrimitive(req.body.phoneNumber, "string")
-  ) {
-    return res.status(400).send(getApiValidationError("phoneNumber", "string"));
-  }
-  return next();
-};

--- a/backend/typescript/middlewares/validators/authValidators.ts
+++ b/backend/typescript/middlewares/validators/authValidators.ts
@@ -75,3 +75,32 @@ export const inviteUserDtoValidator = async (
   }
   return next();
 };
+
+export const updateOwnUserDtoValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (
+    req.body.firstName !== undefined &&
+    req.body.firstName !== null &&
+    !validatePrimitive(req.body.firstName, "string")
+  ) {
+    return res.status(400).send(getApiValidationError("firstName", "string"));
+  }
+  if (
+    req.body.lastName !== undefined &&
+    req.body.lastName !== null &&
+    !validatePrimitive(req.body.lastName, "string")
+  ) {
+    return res.status(400).send(getApiValidationError("lastName", "string"));
+  }
+  if (
+    req.body.phoneNumber !== undefined &&
+    req.body.phoneNumber !== null &&
+    !validatePrimitive(req.body.phoneNumber, "string")
+  ) {
+    return res.status(400).send(getApiValidationError("phoneNumber", "string"));
+  }
+  return next();
+};

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -9,7 +9,6 @@ import {
   loginRequestValidator,
   loginWithSignInLinkRequestValidator,
   inviteUserDtoValidator,
-  updateOwnUserDtoValidator,
 } from "../middlewares/validators/authValidators";
 import nodemailerConfig from "../nodemailer.config";
 import AuthService from "../services/implementations/authService";
@@ -19,7 +18,7 @@ import IAuthService from "../services/interfaces/authService";
 import IEmailService from "../services/interfaces/emailService";
 import IUserService from "../services/interfaces/userService";
 import { getErrorMessage, NotFoundError } from "../utilities/errorUtils";
-import { UserStatus, Role, UserDTO } from "../types";
+import { UserStatus, Role } from "../types";
 
 const authRouter: Router = Router();
 const userService: IUserService = new UserService();
@@ -166,37 +165,6 @@ authRouter.get("/:userId", isAuthorizedByUserId("userId"), async (req, res) => {
       } else {
         res.status(500).json({ error: getErrorMessage(error) });
       }
-    }
-  }
-});
-
-/* Update own user fields: firstName, lastName, phoneNumber */
-authRouter.put("/:userId", updateOwnUserDtoValidator, async (req, res) => {
-  const { userId } = req.params;
-  if (!isAuthorizedByEmail(userId)) {
-    res.status(401).json({ error: "User is not authorized to update fields." });
-    return;
-  }
-
-  try {
-    const user: UserDTO = await userService.getUserById(userId);
-    const updatedUser = await userService.updateUserById(Number(userId), {
-      firstName: req.body.firstName ?? user.firstName,
-      lastName: req.body.lastName ?? user.lastName,
-      email: user.email,
-      role: user.role,
-      status: user.status,
-      skillLevel: user.skillLevel,
-      canSeeAllLogs: user.canSeeAllLogs,
-      canAssignUsersToTasks: user.canAssignUsersToTasks,
-      phoneNumber: req.body.phoneNumber ?? user.phoneNumber,
-    });
-    res.status(200).json(updatedUser);
-  } catch (error: unknown) {
-    if (error instanceof NotFoundError) {
-      res.status(400).json({ error: getErrorMessage(error) });
-    } else {
-      res.status(500).json({ error: getErrorMessage(error) });
     }
   }
 });

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -152,6 +152,23 @@ authRouter.post(
   },
 );
 
+/* Get own user info */
+authRouter.get("/:email", isAuthorizedByEmail("email"), async (req, res) => {
+  const email = req.params.email;
+  if (email) {
+    try {
+      const user = await userService.getUserByEmail(email);
+      res.status(200).json(user);
+    } catch (error: unknown) {
+      if (error instanceof NotFoundError) {
+        res.status(404).send(getErrorMessage(error));
+      } else {
+        res.status(500).json({ error: getErrorMessage(error) });
+      }
+    }
+  }
+});
+
 /* Invite a user */
 authRouter.post("/invite-user", inviteUserDtoValidator, async (req, res) => {
   try {

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -154,11 +154,11 @@ authRouter.post(
 );
 
 /* Get own user info */
-authRouter.get("/:email", isAuthorizedByEmail("email"), async (req, res) => {
-  const { email } = req.params;
-  if (email) {
+authRouter.get("/:userId", isAuthorizedByUserId("userId"), async (req, res) => {
+  const { userId } = req.params;
+  if (userId) {
     try {
-      const user = await userService.getUserByEmail(email);
+      const user = await userService.getUserById(userId);
       res.status(200).json(user);
     } catch (error: unknown) {
       if (error instanceof NotFoundError) {
@@ -171,15 +171,16 @@ authRouter.get("/:email", isAuthorizedByEmail("email"), async (req, res) => {
 });
 
 /* Update own user fields: firstName, lastName, phoneNumber */
-authRouter.put("/:email", updateOwnUserDtoValidator, async (req, res) => {
-  if (!isAuthorizedByEmail(req.params.email)) {
+authRouter.put("/:userId", updateOwnUserDtoValidator, async (req, res) => {
+  const { userId } = req.params;
+  if (!isAuthorizedByEmail(userId)) {
     res.status(401).json({ error: "User is not authorized to update fields." });
     return;
   }
 
   try {
-    const user: UserDTO = await userService.getUserByEmail(req.params.email);
-    const updatedUser = await userService.updateUserById(user.id, {
+    const user: UserDTO = await userService.getUserById(userId);
+    const updatedUser = await userService.updateUserById(Number(userId), {
       firstName: req.body.firstName ?? user.firstName,
       lastName: req.body.lastName ?? user.lastName,
       email: user.email,

--- a/backend/typescript/rest/userRoutes.ts
+++ b/backend/typescript/rest/userRoutes.ts
@@ -211,7 +211,7 @@ userRouter.put("/:userId", updateUserDtoValidator, async (req, res) => {
     const updatedUser = await userService.updateUserById(userId, {
       firstName: req.body.firstName ?? user.firstName,
       lastName: req.body.lastName ?? user.lastName,
-      email: req.body.email ?? user.email,
+      email: user.email,
       role: req.body.role ?? user.role,
       status: req.body.status ?? user.status,
       colorLevel: req.body.colorLevel ?? user.colorLevel,

--- a/backend/typescript/rest/userRoutes.ts
+++ b/backend/typescript/rest/userRoutes.ts
@@ -170,7 +170,12 @@ userRouter.put("/:userId", updateUserDtoValidator, async (req, res) => {
     );
 
     // update own user fields
-    const userUpdatableSet = new Set(["firstName", "lastName", "phoneNumber"]);
+    const userUpdatableSet = new Set([
+      "firstName",
+      "lastName",
+      "phoneNumber",
+      "profilePhoto",
+    ]);
     if (!isAdministrator && hasGivenUserId) {
       const deniedFieldSet = Object.keys(req.body).filter((field) => {
         return !userUpdatableSet.has(field);
@@ -197,6 +202,12 @@ userRouter.put("/:userId", updateUserDtoValidator, async (req, res) => {
         res.status(403).json({ error: deniedFieldsString });
         return;
       }
+    }
+
+    // update other user's fields as admin
+    if (isAdministrator && !hasGivenUserId && req.body.profilePhoto) {
+      res.status(403).json({ error: "Not authorized to update profile photo" });
+      return;
     }
   } catch (error: unknown) {
     if (error instanceof NotFoundError) {


### PR DESCRIPTION
## Notion ticket link
<!-- https://www.notion.so/uwblueprintexecs/Update-User-Route-Permissins-1bd10f3fb1dc809d990dfc2f0c1b4708?pvs=4 -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/aecc07aa87f4429dbd4b5c4287531731?v=17b10f3fb1dc804e92c3000cf3431099&pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added GET endpoint for users to get their own profile info (validated by email)
* Added PUT endpoint for users to update their own profile info (validated by email)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test the GET request: /auth/userId
2. Test the PUT request: /users/userId

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Should the GET request return the entire userDTO or filter it (for stuff like canSeeAllLogs), or can we assume that'll be done in the frontend?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
