### PR TITLE
pagination-limit-done

### DIFF
--- a/backend/typescript/rest/activityTypeRoutes.ts
+++ b/backend/typescript/rest/activityTypeRoutes.ts
@@ -40,8 +40,10 @@ activityTypeRouter.post(
 /* Get all ActivityTypes */
 activityTypeRouter.get("/", async (req, res) => {
   const contentType = req.headers["content-type"];
+  const limit = Number(req.query.limit); //retrieving limit (component) from the database for the page
+  const page = Number(req.query.page); // the actual page we ar on. 
   try {
-    const activityTypes = await activityTypeService.getActivityTypes();
+    const activityTypes = await activityTypeService.getActivityTypes(page, limit);
     await sendResponseByMimeType<ActivityTypeResponseDTO>(
       res,
       200,

--- a/backend/typescript/services/implementations/activityTypeService.ts
+++ b/backend/typescript/services/implementations/activityTypeService.ts
@@ -6,6 +6,7 @@ import {
 } from "../interfaces/activityTypeService";
 import { getErrorMessage, NotFoundError } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
+import { Op } from "sequelize";
 
 const Logger = logger(__filename);
 
@@ -31,10 +32,17 @@ class ActivityTypeService implements IActivityTypeService {
     };
   }
 
-  async getActivityTypes(): Promise<ActivityTypeResponseDTO[]> {
+  async getActivityTypes(page: number, limit: number): Promise<ActivityTypeResponseDTO[]> {
+  
     try {
       const activityTypes: Array<PgActivityType> = await PgActivityType.findAll(
         {
+          where: {
+            id: {
+              [Op.lt]: page*limit + 1,
+              [Op.gt]: (page - 1) * limit
+            }
+          },
           raw: true,
         },
       );

--- a/backend/typescript/services/interfaces/activityTypeService.ts
+++ b/backend/typescript/services/interfaces/activityTypeService.ts
@@ -21,7 +21,7 @@ export interface IActivityTypeService {
    * @returns Returns an array of ActivityTypes
    * @throws Error if retrieval fails
    */
-  getActivityTypes(): Promise<ActivityTypeResponseDTO[]>;
+  getActivityTypes(page: number, limit: number): Promise<ActivityTypeResponseDTO[]>;
 
   /**
    * Create an ActivityType with the fields given in the DTO, return created ActivityType


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add pagination in GET /activityTypes route](https://www.notion.so/uwblueprintexecs/Sprint-Board-4f2ffd2639ac41c4ad0f64818d84d5fa?p=20b10f3fb1dc80f28a7bfa1829f269ab&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Just linked pagination variables with the back end usage of the said variables. Page and limit in speicific were used. 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Just run the program and ping http://localhost:8080/activity-types?page=1&limit=4 
using Postman. You might need to make some sample pages or limits to test it thoroughly, however.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Just focus on ensuring that the three lines retrieving the variable work primarily. The three lines are in activityTypesRoutes.ts in the activityTypeRout.get function. and the activityTypeService.ts line 24 in the getActivityTypes function. 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in the imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
