### PR TITLE
fix NAME in generate-migration makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ generate-migration:
 ifndef NAME
 	$(error NAME argument was not provided. Command should include a NAME parameter)
 endif
-	docker exec -it humane_society_backend /bin/bash -c "node migrate create --name $(name).ts"
+	docker exec -it humane_society_backend /bin/bash -c "node migrate create --name $(NAME).ts"
 
 # Docker Commands
 start-docker:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ stop-docker:
 
 # Database Operations
 clean-db:
-	docker exec -it humane_society_backend /bin/bash -c "node migrate down && node migrate up"
+	docker exec -it humane_society_backend /bin/bash -c "node migrate down --to 0 && node migrate up"
 
 # Seeding script has not been created yet
 seed-db:


### PR DESCRIPTION

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. before this, running `make generate-migration NAME=your-migration-description` in the root folder with backend and db containers running would make a migration file without the 'your-migration-description' in the filename.



## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
