### PR TITLE
Update ActivityService.getUserTasks to have ‘schedule’ prop

### DIFF
--- a/backend/typescript/rest/activityRoutes.ts
+++ b/backend/typescript/rest/activityRoutes.ts
@@ -82,7 +82,7 @@ activityRouter.get(
     if (schedule) {
       const date = new Date(schedule);
       if (Number.isNaN(date.getTime())) {
-        return res.status(400).send("Invalid date.");
+        res.status(400).send("Invalid date.");
       }
 
       activityDto = { time: date };
@@ -93,12 +93,12 @@ activityRouter.get(
         userId,
         activityDto,
       );
-      return res.status(200).json(activitiesByUser);
+      res.status(200).json(activitiesByUser);
     } catch (e: unknown) {
       if (e instanceof NotFoundError) {
-        return res.status(404).send(getErrorMessage(e));
+        res.status(404).send(getErrorMessage(e));
       }
-      return res.status(500).send(getErrorMessage(e));
+      res.status(500).send(getErrorMessage(e));
     }
   },
 );

--- a/backend/typescript/rest/activityRoutes.ts
+++ b/backend/typescript/rest/activityRoutes.ts
@@ -76,7 +76,7 @@ activityRouter.get(
   "/user/:userId/:schedule?", // schedule format: YYYY-MM-DD
   async (
     req: Request<{ userId: string; schedule?: string }>,
-    res,
+    res
   ) => {
     const { userId, schedule } = req.params;
 

--- a/backend/typescript/rest/activityRoutes.ts
+++ b/backend/typescript/rest/activityRoutes.ts
@@ -74,14 +74,14 @@ activityRouter.get("/pet/:petId", async (req, res) => {
 /* Get Activities for specific User by User id */
 activityRouter.get(
   "/user/:userId/:schedule?", // schedule format: YYYY-MM-DD
-  async ( req: Request<{ userId: string; schedule?: string }>, res ) => {
+  async (req: Request<{ userId: string; schedule?: string }>, res) => {
     const { userId, schedule } = req.params;
 
     let activityDto: ActivityTimePatchDTO | undefined;
 
     if (schedule) {
       const date = new Date(schedule);
-      if (isNaN(date.getTime())) {
+      if (Number.isNaN(date.getTime())) {
         return res.status(400).send("Invalid date.");
       }
 
@@ -93,16 +93,13 @@ activityRouter.get(
         userId,
         activityDto,
       );
-      res.status(200).json(activitiesByUser);
+      return res.status(200).json(activitiesByUser);
     } catch (e: unknown) {
       if (e instanceof NotFoundError) {
-        res.status(404).send(getErrorMessage(e));
-      } else {
-        res.status(500).send(getErrorMessage(e));
+        return res.status(404).send(getErrorMessage(e));
       }
+      return res.status(500).send(getErrorMessage(e));
     }
-
-    return;
   },
 );
 

--- a/backend/typescript/rest/activityRoutes.ts
+++ b/backend/typescript/rest/activityRoutes.ts
@@ -74,10 +74,7 @@ activityRouter.get("/pet/:petId", async (req, res) => {
 /* Get Activities for specific User by User id */
 activityRouter.get(
   "/user/:userId/:schedule?", // schedule format: YYYY-MM-DD
-  async (
-    req: Request<{ userId: string; schedule?: string }>,
-    res
-  ) => {
+  async ( req: Request<{ userId: string; schedule?: string }>, res ) => {
     const { userId, schedule } = req.params;
 
     let activityDto: ActivityTimePatchDTO | undefined;
@@ -104,6 +101,8 @@ activityRouter.get(
         res.status(500).send(getErrorMessage(e));
       }
     }
+
+    return;
   },
 );
 

--- a/backend/typescript/services/implementations/activityService.ts
+++ b/backend/typescript/services/implementations/activityService.ts
@@ -1,3 +1,4 @@
+import { Op } from "sequelize";
 import PgActivity from "../../models/activity.model";
 import {
   IActivityService,
@@ -9,7 +10,6 @@ import {
 } from "../interfaces/activityService";
 import { getErrorMessage, NotFoundError } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
-import { Op } from "sequelize";
 
 const Logger = logger(__filename);
 

--- a/backend/typescript/services/implementations/activityService.ts
+++ b/backend/typescript/services/implementations/activityService.ts
@@ -22,7 +22,7 @@ class ActivityService implements IActivityService {
       if (!activity) {
         throw new NotFoundError(`Activity id ${id} not found`);
       }
-    } catch (error: unknown) {
+    } catch (error) {
       Logger.error(
         `Failed to get activity. Reason = ${getErrorMessage(error)}`,
       );
@@ -56,7 +56,7 @@ class ActivityService implements IActivityService {
         endTime: activity.end_time,
         notes: activity.notes,
       }));
-    } catch (error: unknown) {
+    } catch (error) {
       Logger.error(
         `Failed to get activites. Reason = ${getErrorMessage(error)}`,
       );
@@ -85,7 +85,7 @@ class ActivityService implements IActivityService {
         endTime: activity.end_time,
         notes: activity.notes,
       }));
-    } catch (error: unknown) {
+    } catch (error) {
       Logger.error(
         `Failed to get activites. Reason = ${getErrorMessage(error)}`,
       );
@@ -98,7 +98,10 @@ class ActivityService implements IActivityService {
     schedule?: ActivityTimePatchDTO,
   ): Promise<Array<ActivityResponseDTO>> {
     try {
-      const searchClauses: any = {
+      const searchClauses: {
+        user_id: string;
+        start_time?: { [Op.gte]: Date; [Op.lt]: Date };
+      } = {
         user_id,
       };
 
@@ -107,7 +110,6 @@ class ActivityService implements IActivityService {
         const nextDay = new Date(day);
         nextDay.setDate(day.getDate() + 1);
 
-        // start of day <= start_time >= end of day
         searchClauses.start_time = {
           [Op.gte]: day,
           [Op.lt]: nextDay,
@@ -131,7 +133,7 @@ class ActivityService implements IActivityService {
         endTime: activity.end_time,
         notes: activity.notes,
       }));
-    } catch (error: unknown) {
+    } catch (error) {
       Logger.error(
         `Failed to get activites. Reason = ${getErrorMessage(error)}`,
       );
@@ -153,7 +155,7 @@ class ActivityService implements IActivityService {
         end_time: activity.endTime,
         notes: activity.notes,
       });
-    } catch (error: unknown) {
+    } catch (error) {
       Logger.error(
         `Failed to create activity. Reason = ${getErrorMessage(error)}`,
       );
@@ -195,7 +197,7 @@ class ActivityService implements IActivityService {
         throw new NotFoundError(`Activity id ${id} not found`);
       }
       [, [resultingActivity]] = updateResult;
-    } catch (error: unknown) {
+    } catch (error) {
       Logger.error(
         `Failed to update activity. Reason = ${getErrorMessage(error)}`,
       );
@@ -231,7 +233,7 @@ class ActivityService implements IActivityService {
         throw new NotFoundError(`Activity id ${id} not found`);
       }
       [, [resultingActivity]] = updateResult;
-    } catch (error: unknown) {
+    } catch (error) {
       Logger.error(
         `Failed to update activity. Reason = ${getErrorMessage(error)}`,
       );
@@ -267,7 +269,7 @@ class ActivityService implements IActivityService {
         throw new NotFoundError(`Activity id ${id} not found`);
       }
       [, [resultingActivity]] = updateResult;
-    } catch (error: unknown) {
+    } catch (error) {
       Logger.error(
         `Failed to update activity. Reason = ${getErrorMessage(error)}`,
       );
@@ -303,7 +305,7 @@ class ActivityService implements IActivityService {
         throw new NotFoundError(`Activity id ${id} not found`);
       }
       [, [resultingActivity]] = updateResult;
-    } catch (error: unknown) {
+    } catch (error) {
       Logger.error(
         `Failed to update activity. Reason = ${getErrorMessage(error)}`,
       );
@@ -339,7 +341,7 @@ class ActivityService implements IActivityService {
         throw new NotFoundError(`Activity id ${id} not found`);
       }
       [, [resultingActivity]] = updateResult;
-    } catch (error: unknown) {
+    } catch (error) {
       Logger.error(
         `Failed to update activity. Reason = ${getErrorMessage(error)}`,
       );
@@ -375,7 +377,7 @@ class ActivityService implements IActivityService {
         throw new NotFoundError(`Activity id ${id} not found`);
       }
       [, [resultingActivity]] = updateResult;
-    } catch (error: unknown) {
+    } catch (error) {
       Logger.error(
         `Failed to update activity. Reason = ${getErrorMessage(error)}`,
       );
@@ -402,7 +404,7 @@ class ActivityService implements IActivityService {
         throw new NotFoundError(`Activity id ${id} not found`);
       }
       return id;
-    } catch (error: unknown) {
+    } catch (error) {
       Logger.error(
         `Failed to delete activity. Reason = ${getErrorMessage(error)}`,
       );

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -228,9 +228,8 @@ class AuthService implements IAuthService {
     roles: Set<Role>,
   ): Promise<boolean> {
     try {
-      const decodedIdToken: firebaseAdmin.auth.DecodedIdToken = await firebaseAdmin
-        .auth()
-        .verifyIdToken(accessToken, true);
+      const decodedIdToken: firebaseAdmin.auth.DecodedIdToken =
+        await firebaseAdmin.auth().verifyIdToken(accessToken, true);
       const userRole = await this.userService.getUserRoleByAuthId(
         decodedIdToken.uid,
       );
@@ -248,9 +247,8 @@ class AuthService implements IAuthService {
     requestedUserId: string,
   ): Promise<boolean> {
     try {
-      const decodedIdToken: firebaseAdmin.auth.DecodedIdToken = await firebaseAdmin
-        .auth()
-        .verifyIdToken(accessToken, true);
+      const decodedIdToken: firebaseAdmin.auth.DecodedIdToken =
+        await firebaseAdmin.auth().verifyIdToken(accessToken, true);
       const tokenUserId = await this.userService.getUserIdByAuthId(
         decodedIdToken.uid,
       );
@@ -273,9 +271,8 @@ class AuthService implements IAuthService {
     requestedEmail: string,
   ): Promise<boolean> {
     try {
-      const decodedIdToken: firebaseAdmin.auth.DecodedIdToken = await firebaseAdmin
-        .auth()
-        .verifyIdToken(accessToken, true);
+      const decodedIdToken: firebaseAdmin.auth.DecodedIdToken =
+        await firebaseAdmin.auth().verifyIdToken(accessToken, true);
 
       const firebaseUser = await firebaseAdmin
         .auth()

--- a/backend/typescript/services/interfaces/activityService.ts
+++ b/backend/typescript/services/interfaces/activityService.ts
@@ -62,7 +62,10 @@ export interface IActivityService {
    * @returns returns array of Activities
    * @throws Error if retrieval fails
    */
-  getUserActivities(user_id: string): Promise<Array<ActivityResponseDTO>>;
+  getUserActivities(
+    user_id: string,
+    schedule?: ActivityTimePatchDTO,
+  ): Promise<Array<ActivityResponseDTO>>;
 
   /**
    * create a Activity with the fields given in the DTO, return created Activity

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -47,7 +47,7 @@ const sexValues = ["M", "F"] as const;
 
 export const sexEnum: Sex[] = [...sexValues];
 
-export type Sex = typeof sexValues[number];
+export type Sex = (typeof sexValues)[number];
 
 const petStatusValues = [
   "Occupied",
@@ -57,7 +57,7 @@ const petStatusValues = [
 
 export const petStatusEnum: PetStatus[] = [...petStatusValues];
 
-export type PetStatus = typeof petStatusValues[number];
+export type PetStatus = (typeof petStatusValues)[number];
 
 // Skill level is in descending order, where Blue is the most skilled level of a volunteer
 export enum ColorLevel {

--- a/backend/typescript/utilities/firebaseRestClient.ts
+++ b/backend/typescript/utilities/firebaseRestClient.ts
@@ -81,9 +81,8 @@ const FirebaseRestClient = {
       },
     );
 
-    const responseJson:
-      | PasswordSignInResponse
-      | RequestError = await response.json();
+    const responseJson: PasswordSignInResponse | RequestError =
+      await response.json();
 
     if (!response.ok) {
       const errorMessage = [
@@ -123,9 +122,8 @@ const FirebaseRestClient = {
       },
     );
 
-    const responseJson:
-      | OAuthSignInResponse
-      | RequestError = await response.json();
+    const responseJson: OAuthSignInResponse | RequestError =
+      await response.json();
 
     if (!response.ok) {
       const errorMessage = [
@@ -155,9 +153,8 @@ const FirebaseRestClient = {
       },
     );
 
-    const responseJson:
-      | RefreshTokenResponse
-      | RequestError = await response.json();
+    const responseJson: RefreshTokenResponse | RequestError =
+      await response.json();
 
     if (!response.ok) {
       const errorMessage = [


### PR DESCRIPTION
…or all activites that have a start_date on schedule

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Update TaskService.getUserTasks to have ‘schedule’ prop](https://www.notion.so/uwblueprintexecs/Update-TaskService-getUserTasks-to-have-schedule-prop-20d10f3fb1dc8004b196ea6baa63b71d?source=copy_link)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added optional param to route params called schedule
* converted to date in UTC (assuming all dates are in UTC)
* implemented error handling
* passed into activityService.getUserActivities(..., schedule)
* modified sequelize query to search for activities that have start_date on the same day as schedule prop


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Verify the sequelize where clause is accurate
2. test by inputting any date in YYYY-MM-DD format to the query, and see if the results are accurate
3. check for edge cases by having activities on 00:00AM of the day and 11:59PM

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Check above sections


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
