### PR TITLE
Fix Task Template Router

### DIFF
--- a/backend/typescript/middlewares/validators/taskTemplateValidators.ts
+++ b/backend/typescript/middlewares/validators/taskTemplateValidators.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import { getApiValidationError, validatePrimitive } from "./util";
+import { getApiValidationError, validateEnum, validatePrimitive } from "./util";
+import { TaskCategory } from "../../types";
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable-next-line import/prefer-default-export */
@@ -11,6 +12,20 @@ export const taskTemplateRequestDtoValidator = async (
   const { body } = req;
   if (!validatePrimitive(body.taskName, "string")) {
     return res.status(400).send(getApiValidationError("taskName", "string"));
+  }
+  if (!validateEnum(body.category, TaskCategory)) {
+    return res
+      .status(400)
+      .send(getApiValidationError("category", "TaskCategory"));
+  }
+  if (
+    body.instructions !== undefined &&
+    body.instructions !== null &&
+    !validatePrimitive(body.instructions, "string")
+  ) {
+    return res
+      .status(400)
+      .send(getApiValidationError("instructions", "string"));
   }
 
   return next();

--- a/backend/typescript/middlewares/validators/util.ts
+++ b/backend/typescript/middlewares/validators/util.ts
@@ -6,7 +6,8 @@ type Type =
   | "PetStatus"
   | "Sex"
   | "Date"
-  | "AnimalTag";
+  | "AnimalTag"
+  | "TaskCategory";
 
 const allowableContentTypes = new Set([
   "text/plain",

--- a/backend/typescript/rest/taskTemplateRoutes.ts
+++ b/backend/typescript/rest/taskTemplateRoutes.ts
@@ -25,6 +25,8 @@ taskTemplateRouter.post(
       const { body } = req;
       const newTaskTemplate = await taskTemplateService.createTaskTemplate({
         taskName: body.taskName,
+        category: body.category,
+        instructions: body.instructions,
       });
       res.status(201).json(newTaskTemplate);
     } catch (e: unknown) {
@@ -85,6 +87,8 @@ taskTemplateRouter.put(
       const { body } = req;
       const taskTemplate = await taskTemplateService.updateTaskTemplate(id, {
         taskName: body.taskName,
+        category: body.category,
+        instructions: body.instructions,
       });
       res.status(200).json(taskTemplate);
     } catch (e: unknown) {

--- a/backend/typescript/services/implementations/taskTemplateService.ts
+++ b/backend/typescript/services/implementations/taskTemplateService.ts
@@ -28,6 +28,8 @@ class TaskTemplateService implements ITaskTemplateService {
     return {
       id: taskTemplate.id,
       taskName: taskTemplate.task_name,
+      category: taskTemplate.category,
+      instructions: taskTemplate.instruction,
     };
   }
 
@@ -41,6 +43,8 @@ class TaskTemplateService implements ITaskTemplateService {
       return taskTemplates.map((taskTemplate) => ({
         id: taskTemplate.id,
         taskName: taskTemplate.task_name,
+        category: taskTemplate.category,
+        instructions: taskTemplate.instruction,
       }));
     } catch (error) {
       Logger.error(
@@ -57,6 +61,8 @@ class TaskTemplateService implements ITaskTemplateService {
     try {
       newTaskTemplate = await PgTaskTemplate.create({
         task_name: taskTemplate.taskName,
+        category: taskTemplate.category,
+        instruction: taskTemplate.instructions,
       });
     } catch (error) {
       Logger.error(
@@ -67,6 +73,8 @@ class TaskTemplateService implements ITaskTemplateService {
     return {
       id: newTaskTemplate.id,
       taskName: newTaskTemplate.task_name,
+      category: newTaskTemplate.category,
+      instructions: newTaskTemplate.instruction,
     };
   }
 
@@ -80,6 +88,8 @@ class TaskTemplateService implements ITaskTemplateService {
       updateResult = await PgTaskTemplate.update(
         {
           task_name: taskTemplate.taskName,
+          category: taskTemplate.category,
+          instruction: taskTemplate.instructions,
         },
         { where: { id }, returning: true },
       );
@@ -97,6 +107,8 @@ class TaskTemplateService implements ITaskTemplateService {
     return {
       id: resultingTaskTemplate.id,
       taskName: resultingTaskTemplate?.task_name,
+      category: resultingTaskTemplate?.category,
+      instructions: resultingTaskTemplate?.instruction,
     };
   }
 

--- a/backend/typescript/services/interfaces/taskTemplateService.ts
+++ b/backend/typescript/services/interfaces/taskTemplateService.ts
@@ -1,10 +1,16 @@
+import { TaskCategory } from "../../types";
+
 export interface TaskTemplateRequestDTO {
   taskName: string;
+  category: TaskCategory;
+  instructions?: string;
 }
 
 export interface TaskTemplateResponseDTO {
   id: number;
   taskName: string;
+  category: TaskCategory;
+  instructions?: string;
 }
 
 export interface ITaskTemplateService {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix taskTemplateRouter.post to also take category and instructions in req body](https://www.notion.so/uwblueprintexecs/Fix-taskTemplateRouter-post-to-also-take-category-and-instructions-in-req-body-22f10f3fb1dc80fe8902fd761e8f24ba)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run Postman against localhost:8080/task-templates and send a post with the fields (instructions not mandatory)
```json
{
    "taskName": "Task Name",
    "category": "Games",
    "instructions": "Here are the instructions"
}
```
3. The update affects the get, put, and post of that route as well

