### PR TITLE
created volunteer view edit user profile

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,9 @@ import PageTitleUpdater from "./components/common/PageTitleUpdater";
 import { AuthenticatedUser } from "./types/AuthTypes";
 import DevFileStorageUpload from "./pages/DevFileStorageUpload";
 
+import { UserRoles } from "./constants/UserConstants";
+import VolunteerViewEditUserProfilePage from "./pages/VolunteerViewEditUserProfilePage";
+
 const App = (): React.ReactElement => {
   const currentUser: AuthenticatedUser = getLocalStorageObj<AuthenticatedUser>(
     AUTHENTICATED_USER_KEY,
@@ -204,6 +207,12 @@ const App = (): React.ReactElement => {
                     path={Routes.ADD_TASK_TEMPLATE_PAGE}
                     component={AddTaskTemplatePage}
                     allowedRoles={AuthConstants.ADMIN_AND_BEHAVIOURISTS}
+                  />
+                  <PrivateRoute
+                    exact
+                    path={Routes.VOLUNTEER_EDIT_USER_PROFILE_PAGE}
+                    component={VolunteerViewEditUserProfilePage}
+                    allowedRoles={AuthConstants.ALL_ROLES}
                   />
                   {/* Fallback Route */}
                   <Route path="*" component={NotFoundPage} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,7 +50,6 @@ const App = (): React.ReactElement => {
     AUTHENTICATED_USER_KEY,
   );
 
-  console.log("Current User:", currentUser);
   const [authenticatedUser, setAuthenticatedUser] =
     useState<AuthenticatedUser>(currentUser);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,6 +50,7 @@ const App = (): React.ReactElement => {
     AUTHENTICATED_USER_KEY,
   );
 
+  console.log("Current User:", currentUser);
   const [authenticatedUser, setAuthenticatedUser] =
     useState<AuthenticatedUser>(currentUser);
 
@@ -209,7 +210,7 @@ const App = (): React.ReactElement => {
                   />
                   <PrivateRoute
                     exact
-                    path={Routes.VOLUNTEER_EDIT_USER_PROFILE_PAGE}
+                    path={`${Routes.VOLUNTEER_EDIT_USER_PROFILE_PAGE}/:userId`}
                     component={VolunteerViewEditUserProfilePage}
                     allowedRoles={AuthConstants.ALL_ROLES}
                   />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,7 +43,6 @@ import PageTitleUpdater from "./components/common/PageTitleUpdater";
 import { AuthenticatedUser } from "./types/AuthTypes";
 import DevFileStorageUpload from "./pages/DevFileStorageUpload";
 
-import { UserRoles } from "./constants/UserConstants";
 import VolunteerViewEditUserProfilePage from "./pages/VolunteerViewEditUserProfilePage";
 
 const App = (): React.ReactElement => {

--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -31,9 +31,9 @@ const SIZE_STYLES = {
     fontSize: "1.125rem",
   },
   large: {
-    paddingY: "0.625rem",
+    paddingY: "0.8rem",
     paddingX: "1.875rem",
-    fontSize: "1.5rem",
+    fontSize: "1.125rem",
   },
 };
 

--- a/frontend/src/components/common/PasswordInput.tsx
+++ b/frontend/src/components/common/PasswordInput.tsx
@@ -1,55 +1,92 @@
-import React from "react";
-import { IconButton, InputGroup, InputRightElement } from "@chakra-ui/react";
+import React, { ChangeEvent, useState } from "react";
+import {
+  FormControl,
+  FormLabel,
+  Input as ChakraInput,
+  FormErrorMessage,
+  IconButton,
+  InputGroup,
+  InputRightElement,
+} from "@chakra-ui/react";
 import { ViewIcon, ViewOffIcon } from "@chakra-ui/icons";
-import Input from "./Input";
 
-interface PasswordInputProps {
+interface PasswordInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size"> {
+  label?: string;
   value: string;
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  error?: string;
+  required?: boolean;
   disabled?: boolean;
+  showToggle?: boolean;
 }
 
 const PasswordInput = ({
+  label,
   value,
   onChange,
+  error,
+  required = false,
   disabled = false,
+  showToggle = true,
+  ...props
 }: PasswordInputProps): React.ReactElement => {
-  const [showPassword, setShowPassword] = React.useState(false);
-  const handlePasswordClick = () => setShowPassword(!showPassword);
+  const [showPassword, setShowPassword] = useState(false);
+  const handlePasswordToggle = () => setShowPassword(!showPassword);
 
   return (
-    <InputGroup size="lg">
-      <Input
-        type={showPassword ? "text" : "password"}
-        value={value}
-        placeholder="••••••••••"
-        onChange={onChange}
-        disabled={disabled}
-      />
-      <InputRightElement width="2rem" top="50%" transform="translateY(-50%)">
-        {showPassword ? (
-          <IconButton
-            variant="unstyled"
-            isRound
-            bg="transparent"
-            onClick={handlePasswordClick}
-            aria-label="view"
-            icon={<ViewIcon />}
-            color="gray.400"
-          />
-        ) : (
-          <IconButton
-            variant="unstyled"
-            isRound
-            bg="transparent"
-            onClick={handlePasswordClick}
-            aria-label="hide"
-            icon={<ViewOffIcon />}
-            color="gray.400"
-          />
+    <FormControl isInvalid={!!error} isRequired={required}>
+      {label && (
+        <FormLabel
+          mb="8px"
+          fontSize="14px"
+          fontWeight="500"
+          color={error ? "red.500" : "gray.600"}
+        >
+          {label}
+        </FormLabel>
+      )}
+      <InputGroup size="lg">
+        <ChakraInput
+          type={showPassword ? "text" : "password"}
+          size="lg"
+          borderRadius="md"
+          borderWidth="1px"
+          borderColor={error ? "red.500" : "gray.400"}
+          bg={disabled ? "gray.100" : "white.default"}
+          _placeholder={{ color: "gray.400" }}
+          placeholder="••••••••••"
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          _focus={{
+            borderColor: error ? "red.500" : "blue.500",
+            boxShadow: error ? "0 0 0 1px red" : "0 0 0 1px blue",
+          }}
+          _disabled={{
+            bg: "gray.100",
+            color: "gray.500",
+            cursor: "not-allowed",
+          }}
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...props}
+        />
+        {showToggle && (
+          <InputRightElement>
+            <IconButton
+              variant="unstyled"
+              size="sm"
+              onClick={handlePasswordToggle}
+              aria-label={showPassword ? "Hide password" : "Show password"}
+              icon={showPassword ? <ViewOffIcon /> : <ViewIcon />}
+              color="gray.400"
+              _hover={{ color: "gray.600" }}
+            />
+          </InputRightElement>
         )}
-      </InputRightElement>
-    </InputGroup>
+      </InputGroup>
+      {error && <FormErrorMessage fontSize="12px">{error}</FormErrorMessage>}
+    </FormControl>
   );
 };
 

--- a/frontend/src/components/common/PasswordInput.tsx
+++ b/frontend/src/components/common/PasswordInput.tsx
@@ -6,11 +6,13 @@ import Input from "./Input";
 interface PasswordInputProps {
   value: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
 }
 
 const PasswordInput = ({
   value,
   onChange,
+  disabled = false,
 }: PasswordInputProps): React.ReactElement => {
   const [showPassword, setShowPassword] = React.useState(false);
   const handlePasswordClick = () => setShowPassword(!showPassword);
@@ -22,6 +24,7 @@ const PasswordInput = ({
         value={value}
         placeholder="••••••••••"
         onChange={onChange}
+        disabled={disabled}
       />
       <InputRightElement width="2rem" top="50%" transform="translateY(-50%)">
         {showPassword ? (

--- a/frontend/src/components/common/ProfilePhoto.tsx
+++ b/frontend/src/components/common/ProfilePhoto.tsx
@@ -33,7 +33,6 @@ const ProfilePhoto = ({
   type,
 }: ProfilePhotoProps): React.ReactElement => {
   const isSmall = size === "small";
-  const containerSize = isSmall ? "2.625rem" : "8.69rem";
   const imageSize = isSmall ? "2.25rem" : "8.06rem";
 
   const fallbackImage = fallbackImages[type];
@@ -41,8 +40,7 @@ const ProfilePhoto = ({
     type === "invitedUser" ? "gray.300" : color && borderColor[color];
   return (
     <Flex
-      p="0.19rem"
-      boxSize={containerSize}
+      p="0rem"
       justify="center"
       align="center"
       borderRadius="full"

--- a/frontend/src/components/common/userprofile/UserProfileSidebar.tsx
+++ b/frontend/src/components/common/userprofile/UserProfileSidebar.tsx
@@ -25,6 +25,7 @@ import { AnimalTag, colorLevelMap } from "../../../types/TaskTypes";
 import AnimalTagList from "./AnimalTagList";
 import Logout from "../../auth/Logout";
 import InviteUser from "./InviteUser";
+import getCurrentUserRole from "../../../utils/CommonUtils";
 
 export interface UserProfileSidebarProps {
   id: number;
@@ -52,6 +53,12 @@ function UserProfileSidebar({
   animalTags,
 }: UserProfileSidebarProps): React.ReactElement {
   const isInvited = status === "Invited";
+  const currentUserRole = getCurrentUserRole();
+  const isCurrentUserAdmin = currentUserRole === UserRoles.ADMIN;
+
+  const editUserProfilePath = isCurrentUserAdmin
+    ? `/admin/edit-user-profile/${id}`
+    : `/edit-user-profile/${id}`;
 
   const roleIcons: Record<UserRoles, React.ElementType> = {
     [UserRoles.ADMIN]: AdminTag,
@@ -80,7 +87,7 @@ function UserProfileSidebar({
           {firstName} {lastName}
         </Text>
         <Spacer />
-        <ChakraLink as={Link} to={`/admin/edit-user-profile/${id}`}>
+        <ChakraLink as={Link} to={editUserProfilePath}>
           <Image src={PencilIcon} alt="edit" boxSize="1.2rem" />
         </ChakraLink>
       </HStack>

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -46,3 +46,5 @@ export const UPDATE_SIMPLE_ENTITY_PAGE = "/simpleEntity/update";
 export const HOOKS_PAGE = "/hooks";
 
 export const DEV_FILE_STORAGE_UPLOAD_PAGE = "/dev-file-upload";
+
+export const VOLUNTEER_EDIT_USER_PROFILE_PAGE = "/edit-user-profile";

--- a/frontend/src/hooks/useFileUploadManager.ts
+++ b/frontend/src/hooks/useFileUploadManager.ts
@@ -1,0 +1,169 @@
+import { useState, useEffect, useCallback } from "react";
+import { useToast } from "@chakra-ui/react";
+import EntityAPIClient, { EntityResponse } from "../APIClients/EntityAPIClient";
+
+export interface FileStatus {
+  id: string;
+  name: string;
+  status: "uploaded" | "error";
+  url?: string;
+}
+
+const buildFormData = (file: File) => {
+  const entityData = {
+    stringField: file.name,
+    intField: 0,
+    enumField: "A",
+    stringArrayField: [],
+    boolField: true,
+  };
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("body", JSON.stringify(entityData));
+  return formData;
+};
+
+const mapApiResponseToFileStatus = (resp: EntityResponse): FileStatus => ({
+  id: resp.id.toString(),
+  name: resp.fileName,
+  status: "uploaded",
+});
+
+export function useFileUploadManager(maxFileSizeMB: number = 25) {
+  const [uploadedFiles, setUploadedFiles] = useState<FileStatus[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const toast = useToast();
+
+  const fetchFileUrl = useCallback(async (fileName: string) => {
+    try {
+      const fileUrl = await EntityAPIClient.getFile(fileName);
+      if (fileUrl) {
+        setUploadedFiles((prevFiles: FileStatus[]) =>
+          prevFiles.map((file: FileStatus) =>
+            file.name === fileName ? { ...file, url: fileUrl } : file,
+          ),
+        );
+      }
+    } catch (err) {
+      console.error("Failed to fetch file URL:", err);
+    }
+  }, []);
+
+  const fetchAllFiles = useCallback(async () => {
+    try {
+      setUploadedFiles([]);
+      const entities = await EntityAPIClient.get();
+      if (!entities || !Array.isArray(entities)) {
+        setUploadedFiles([]);
+        setError("No files available or error occurred");
+        return;
+      }
+      const files: FileStatus[] = entities.map(mapApiResponseToFileStatus);
+      setUploadedFiles(files);
+      const urlPromises = files.map(async (file) => {
+        try {
+          const fileUrl = await EntityAPIClient.getFile(file.name);
+          if (!fileUrl) throw new Error("File URL does not exist");
+          return { name: file.name, url: fileUrl };
+        } catch (err) {
+          console.error(`Failed to fetch URL for file ${file.name}:`, err);
+          return null;
+        }
+      });
+      const results = await Promise.all(urlPromises);
+      setUploadedFiles((prevFiles) =>
+        prevFiles.map((prevFile) => {
+          const result = results.find((r) => r?.name === prevFile.name);
+          return result?.url ? { ...prevFile, url: result.url } : prevFile;
+        }),
+      );
+    } catch (err) {
+      console.error("Failed to fetch files:", err);
+      setError("Failed to load existing files");
+      setUploadedFiles([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAllFiles();
+  }, [fetchAllFiles]);
+
+  const handleUpload = async (files: FileList | null) => {
+    if (!files?.length) return;
+    const file = files[0];
+    const MAX_FILE_SIZE = maxFileSizeMB * 1024 * 1024;
+    if (file.size > MAX_FILE_SIZE) {
+      setError(`File size exceeds ${maxFileSizeMB}MB limit`);
+      toast({
+        title: "File too large",
+        description: `Maximum file size is ${maxFileSizeMB}MB`,
+        status: "error",
+        duration: 3000,
+      });
+      return;
+    }
+    setIsUploading(true);
+    setError(null);
+    try {
+      const formData = buildFormData(file);
+      const response = await EntityAPIClient.create({ formData });
+      if (!response) {
+        throw new Error("Upload failed - no response");
+      }
+      const { fileName } = response;
+      if (!fileName) {
+        throw new Error("Upload failed - no fileName in response");
+      }
+      const fileUrl = await EntityAPIClient.getFile(fileName);
+      const newFile: FileStatus = {
+        ...mapApiResponseToFileStatus(response),
+        url: fileUrl || undefined,
+      };
+      setUploadedFiles((prev) => [...prev, newFile]);
+      toast({
+        title: "File uploaded successfully",
+        status: "success",
+        duration: 3000,
+      });
+    } catch (err) {
+      console.error("Upload failed:", err);
+      setError("Failed to upload file");
+      toast({
+        title: "Upload failed",
+        status: "error",
+        duration: 3000,
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await EntityAPIClient.deleteEntity(id);
+      setUploadedFiles((prev) => prev.filter((file) => file.id !== id));
+      toast({
+        title: "File deleted successfully",
+        status: "success",
+        duration: 3000,
+      });
+    } catch (err) {
+      console.error("Delete failed:", err);
+      toast({
+        title: "Failed to delete file",
+        status: "error",
+        duration: 3000,
+      });
+    }
+  };
+
+  return {
+    uploadedFiles,
+    isUploading,
+    error,
+    handleUpload,
+    handleDelete,
+    fetchFileUrl,
+  };
+}

--- a/frontend/src/pages/AdminViewEditUserProfilePage.tsx
+++ b/frontend/src/pages/AdminViewEditUserProfilePage.tsx
@@ -157,6 +157,7 @@ const AdminViewEditUserProfilePage = (): React.ReactElement => {
         >
           {/* Back Button */}
           <Flex
+            width="fit-content"
             display="flex"
             alignItems="center"
             gap="0.5rem"
@@ -166,7 +167,7 @@ const AdminViewEditUserProfilePage = (): React.ReactElement => {
             _hover={{ opacity: 0.7 }}
           >
             <ChevronLeftIcon color="gray.600" boxSize="1.25rem" />
-            <Text m={0} textStyle="Body" color="gray.600">
+            <Text m={0} textStyle="body" color="gray.600">
               Back to Profile
             </Text>
           </Flex>

--- a/frontend/src/pages/VolunteerViewEditUserProfilePage.tsx
+++ b/frontend/src/pages/VolunteerViewEditUserProfilePage.tsx
@@ -1,5 +1,5 @@
-import React, { useContext, useEffect, useState } from "react";
-import { Flex, Text, FormLabel, Spinner, Icon, Image } from "@chakra-ui/react";
+import React, { useContext, useState } from "react";
+import { Flex, Text, FormLabel, Spinner, Image } from "@chakra-ui/react";
 import { useForm, Controller } from "react-hook-form";
 import { ChevronLeftIcon } from "@chakra-ui/icons";
 import { useHistory } from "react-router-dom";

--- a/frontend/src/pages/VolunteerViewEditUserProfilePage.tsx
+++ b/frontend/src/pages/VolunteerViewEditUserProfilePage.tsx
@@ -284,7 +284,7 @@ const VolunteerViewEditUserProfilePage = (): React.ReactElement => {
                 )}
               />
 
-              <Flex width="100%" gap="1.5rem">
+              <Flex width="100%" gap="1.5rem" alignItems="end">
                 <Flex flex={1}>
                   <Controller
                     name="password"
@@ -295,7 +295,7 @@ const VolunteerViewEditUserProfilePage = (): React.ReactElement => {
                         value={field.value}
                         onChange={field.onChange}
                         disabled
-                        showToggle
+                        showToggle={false}
                       />
                     )}
                   />

--- a/frontend/src/pages/VolunteerViewEditUserProfilePage.tsx
+++ b/frontend/src/pages/VolunteerViewEditUserProfilePage.tsx
@@ -1,0 +1,276 @@
+import React, { useContext, useEffect, useState } from "react";
+import { Flex, Text, FormLabel, Spinner, Icon, Image } from "@chakra-ui/react";
+import { useForm, Controller } from "react-hook-form";
+import { ChevronLeftIcon } from "@chakra-ui/icons";
+import { useHistory } from "react-router-dom";
+import Input from "../components/common/Input";
+import PasswordInput from "../components/common/PasswordInput";
+import Button from "../components/common/Button";
+import NavBar from "../components/common/navbar/NavBar";
+import ProfilePhoto from "../components/common/ProfilePhoto";
+import AuthContext from "../contexts/AuthContext";
+import PencilIcon from "../assets/icons/pencil.svg";
+
+interface FormData {
+  userId: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber: string;
+  email: string;
+  password: string;
+  profilePhoto: string;
+}
+
+const VolunteerViewEditUserProfilePage = (): React.ReactElement => {
+  const { authenticatedUser } = useContext(AuthContext);
+  const history = useHistory();
+  const [localProfilePhoto, setLocalProfilePhoto] = useState<
+    string | undefined
+  >(authenticatedUser?.profilePhoto || undefined);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm<FormData>({
+    defaultValues: {
+      userId: authenticatedUser?.id?.toString() || "",
+      firstName: authenticatedUser?.firstName || "",
+      lastName: authenticatedUser?.lastName || "",
+      phoneNumber: authenticatedUser?.phoneNumber || "",
+      email: authenticatedUser?.email || "",
+      password: "",
+      profilePhoto: authenticatedUser?.profilePhoto || "",
+    },
+  });
+
+  if (!authenticatedUser) {
+    return (
+      <Flex justify="center" align="center" height="100vh">
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  const onSubmit = (data: FormData) => {
+    console.log({
+      userId: data.userId,
+      firstName: data.firstName,
+      lastName: data.lastName,
+      phoneNumber: data.phoneNumber,
+      profilePhoto: localProfilePhoto,
+    });
+  };
+
+  const handleChangePassword = () => {
+    history.push("/forgot-password");
+  };
+
+  const handleProfilePhotoChange = (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const file = files[0];
+    const reader = new FileReader();
+    setIsUploading(true);
+    reader.onloadend = () => {
+      setLocalProfilePhoto(reader.result as string);
+      setValue("profilePhoto", reader.result as string, {
+        shouldValidate: true,
+      });
+      setIsUploading(false);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <>
+      <NavBar pageName="User Profile" />
+      <Flex
+        width="100%"
+        paddingTop="7.5rem"
+        backgroundColor="gray.50"
+        justifyContent="center"
+        minHeight="100vh"
+      >
+        <Flex
+          flexDirection="column"
+          width="100%"
+          maxWidth="85rem"
+          mx="auto"
+          p="1.5rem"
+        >
+          <Flex
+            width="fit-content"
+            display="flex"
+            alignItems="center"
+            gap="0.5rem"
+            mb="1.5rem"
+            cursor="pointer"
+            onClick={() => window.history.back()}
+            _hover={{ opacity: 0.7 }}
+          >
+            <ChevronLeftIcon color="gray.600" boxSize="1.25rem" />
+            <Text m={0} textStyle="body" color="gray.600">
+              Back to Profile
+            </Text>
+          </Flex>
+
+          <Text textStyle="h2" mb="2rem" m={0}>
+            Edit Profile
+          </Text>
+
+          <Flex
+            direction="column"
+            align="center"
+            mb="2.5rem"
+            gap="0.5rem"
+            position="relative"
+          >
+            <FormLabel m={0} textStyle="body" color="gray.700">
+              Profile Picture:
+            </FormLabel>
+            <Flex position="relative" align="center" justifyContent="center">
+              <ProfilePhoto
+                size="large"
+                type="user"
+                image={localProfilePhoto}
+              />
+              <Flex
+                as="label"
+                htmlFor="profile-photo-upload"
+                position="absolute"
+                right="0"
+                top="0"
+                width="2.5rem"
+                height="2.5rem"
+                borderRadius="50%"
+                backgroundColor="gray.200"
+                alignItems="center"
+                justifyContent="center"
+                cursor="pointer"
+                border="none"
+                zIndex={2}
+              >
+                <Image
+                  src={PencilIcon}
+                  alt="edit"
+                  style={{ stroke: "black" }}
+                />
+              </Flex>
+              <input
+                type="file"
+                accept="image/*"
+                style={{ display: "none" }}
+                id="profile-photo-upload"
+                onChange={(e) => handleProfilePhotoChange(e.target.files)}
+                disabled={isUploading}
+              />
+            </Flex>
+          </Flex>
+
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <Flex direction="column" gap="1.5rem">
+              <Flex width="100%" gap="1.5rem">
+                <Controller
+                  name="firstName"
+                  control={control}
+                  rules={{ required: "First name is required" }}
+                  render={({ field }) => (
+                    <Input
+                      label="First Name"
+                      placeholder="Enter first name"
+                      value={field.value}
+                      onChange={field.onChange}
+                      error={errors.firstName?.message}
+                      required
+                    />
+                  )}
+                />
+                <Controller
+                  name="lastName"
+                  control={control}
+                  rules={{ required: "Last name is required" }}
+                  render={({ field }) => (
+                    <Input
+                      label="Last Name"
+                      placeholder="Enter last name"
+                      value={field.value}
+                      onChange={field.onChange}
+                      error={errors.lastName?.message}
+                      required
+                    />
+                  )}
+                />
+              </Flex>
+
+              <Controller
+                name="phoneNumber"
+                control={control}
+                render={({ field }) => (
+                  <Input
+                    label="Phone Number"
+                    placeholder="Enter phone number"
+                    value={field.value}
+                    onChange={field.onChange}
+                    error={errors.phoneNumber?.message}
+                  />
+                )}
+              />
+
+              <Controller
+                name="email"
+                control={control}
+                render={({ field }) => (
+                  <Input
+                    label="Email"
+                    placeholder="Enter email"
+                    value={field.value}
+                    onChange={field.onChange}
+                    error={errors.email?.message}
+                    disabled
+                  />
+                )}
+              />
+
+              <Flex width="100%" gap="1.5rem">
+                <Flex flex={1}>
+                  <Controller
+                    name="password"
+                    control={control}
+                    render={({ field }) => (
+                      <PasswordInput
+                        value={field.value}
+                        onChange={field.onChange}
+                        disabled
+                      />
+                    )}
+                  />
+                </Flex>
+                <Flex flex={1} align="center">
+                  <Button
+                    variant="dark-blue"
+                    size="large"
+                    width="100%"
+                    type="button"
+                    onClick={handleChangePassword}
+                  >
+                    Change Password
+                  </Button>
+                </Flex>
+              </Flex>
+
+              <Flex justify="flex-end" mt="2rem">
+                <Button variant="green" size="medium" type="submit">
+                  Save
+                </Button>
+              </Flex>
+            </Flex>
+          </form>
+        </Flex>
+      </Flex>
+    </>
+  );
+};
+
+export default VolunteerViewEditUserProfilePage;


### PR DESCRIPTION
## Notion ticket
[Create Volunteer View Edit User Profile Page UI](https://www.notion.so/uwblueprintexecs/Create-Volunteer-View-Edit-User-Profile-Page-UI-22610f3fb1dc80b5a5d8eb4d1f862537?source=copy_link)

## What’s changed
- Created `VolunteerViewEditUserProfilePage.tsx` for volunteers to view and edit their profile.
- Added form fields for first name, last name, phone number, email (read-only), and profile photo.
- Implemented profile photo upload and preview.
- Added "Change Password" button (redirects to forgot password page).
- Integrated with AuthContext to pre-fill user data.
- UI styled with Chakra UI components.

## Steps to test
1. Log in as admin.
2. Go to the http://localhost:3000/edit-user-profile
3. Verify the following:
   - All fields (first name, last name, phone number, email) are pre-filled with your info.
   - Email and password fields are disabled.
   - You can update your first name, last name, and phone number.
   - You can upload a new profile photo and see a preview.
   - Clicking "Change Password" takes you to the forgot password page.
   - Clicking "Save" logs the updated info to the console (no backend update yet).
   - "Back to Profile" link works as expected.
4. Confirm the UI matches the design and is responsive.