### PR TITLE
Add TaskTemplateAPIClient

### DIFF
--- a/frontend/src/APIClients/TaskTemplateAPIClient.ts
+++ b/frontend/src/APIClients/TaskTemplateAPIClient.ts
@@ -1,0 +1,102 @@
+import baseAPIClient from "./BaseAPIClient";
+import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
+import { getLocalStorageObjProperty } from "../utils/LocalStorageUtils";
+import { CreateTaskDTO, EditTaskDTO, Task } from "../types/TaskTypes";
+
+const getTaskTemplate = async (taskTemplateId: number): Promise<Task> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+  try {
+    const { data } = await baseAPIClient.get(
+      `/task-templates/${taskTemplateId}`,
+      {
+        headers: { Authorization: bearerToken },
+      },
+    );
+    return data;
+  } catch (error) {
+    throw new Error(`Failed to fetch task template: ${error}`);
+  }
+};
+
+const getAllTaskTemplates = async (): Promise<Task[]> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+  try {
+    const { data } = await baseAPIClient.get("/task-templates", {
+      headers: { Authorization: bearerToken },
+    });
+    return data;
+  } catch (error) {
+    throw new Error(`Failed to fetch task templates: ${error}`);
+  }
+};
+
+const createTaskTemplate = async (formData: CreateTaskDTO): Promise<Task> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+  try {
+    const { data } = await baseAPIClient.post("/task-templates", formData, {
+      headers: { Authorization: bearerToken },
+    });
+    return data;
+  } catch (error) {
+    throw new Error(`Failed to create task template: ${error}`);
+  }
+};
+
+const editTaskTemplate = async (
+  taskTemplateId: number | string,
+  formData: EditTaskDTO,
+): Promise<Task> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+  try {
+    const { data } = await baseAPIClient.put(
+      `/task-templates/${taskTemplateId}`,
+      formData,
+      {
+        headers: { Authorization: bearerToken },
+      },
+    );
+    return data;
+  } catch (error) {
+    throw new Error(`Failed to edit task template: ${error}`);
+  }
+};
+
+const deleteTaskTemplate = async (
+  taskTemplateId: number | string,
+): Promise<{ taskTemplateId: number }> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+  try {
+    const { data } = await baseAPIClient.delete(
+      `/task-templates/${taskTemplateId}`,
+      {
+        headers: { Authorization: bearerToken },
+      },
+    );
+    return data;
+  } catch (error) {
+    throw new Error(`Failed to delete task template: ${error}`);
+  }
+};
+
+export default {
+  getTaskTemplate,
+  getAllTaskTemplates,
+  createTaskTemplate,
+  editTaskTemplate,
+  deleteTaskTemplate,
+};

--- a/frontend/src/types/TaskTypes.ts
+++ b/frontend/src/types/TaskTypes.ts
@@ -44,6 +44,16 @@ export interface Task {
   instructions: string;
 }
 
+export type CreateTaskDTO = {
+  taskName: string;
+  category: TaskCategory;
+  instructions?: string;
+};
+// Allow instructions to be null to set database value to null
+export type EditTaskDTO = Omit<CreateTaskDTO, "instructions"> & {
+  instructions?: string | null;
+};
+
 export const mockTasks: Task[] = [
   {
     id: 1,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Create TaskTemplateAPIClient with getAllTaskTemplates, addTaskTemplate, editTaskTemplate, deleteTaskTemplate, getTaskTemplate methods](https://www.notion.so/uwblueprintexecs/Create-TaskTemplateAPIClient-with-getAllTaskTemplates-addTaskTemplate-editTaskTemplate-deleteTask-23110f3fb1dc80d48f17faf7b6b9057c)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a button whose onClick is the function you would like to test, and console log the data result
```javascript
<Button
  onClick={async () => {
    const data = await TaskTemplateAPIClient.getAllTaskTemplates();
    console.log(data);
  }}
>
  Get all task templates
</Button>
```
3. Click the button and see if the output matches

I have already tested the functions so ideally they should be ok

