### PR TITLE
Edit pet profile functionality

### DIFF
--- a/backend/typescript/services/implementations/petService.ts
+++ b/backend/typescript/services/implementations/petService.ts
@@ -277,9 +277,19 @@ class PetService implements IPetService {
           },
           { where: { pet_id: id }, returning: true, transaction },
         );
-        // pet care info is not required anymore
         if (petCareInfoUpdateResult[0]) {
           [, [resultingPetCareInfo]] = petCareInfoUpdateResult;
+        } else {
+          // if no existing row in pet care info, create
+          resultingPetCareInfo = await PgPetCareInfo.create(
+            {
+              pet_id: Number(id),
+              safety_info: pet.careInfo?.safetyInfo,
+              medical_info: pet.careInfo?.medicalInfo,
+              management_info: pet.careInfo?.managementInfo,
+            },
+            { transaction },
+          );
         }
       }
 

--- a/frontend/src/APIClients/PetAPIClient.ts
+++ b/frontend/src/APIClients/PetAPIClient.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
-import { Pet, PetListSections } from "../types/PetTypes";
+import { Pet, PetListSections, PetRequestDTO } from "../types/PetTypes";
 import { Task } from "../types/TaskTypes";
 import { getLocalStorageObjProperty } from "../utils/LocalStorageUtils";
 import baseAPIClient from "./BaseAPIClient";
@@ -102,4 +102,17 @@ const deletePet = async (petId: number | string): Promise<void> => {
   }
 };
 
-export default { getPetTasks, getPet, getPets, getPetList, deletePet };
+const update = async (petId: number, formData: PetRequestDTO): Promise<Pet> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+
+  const { data } = await baseAPIClient.put(`/pets/${petId}`, formData, {
+    headers: { Authorization: bearerToken },
+  });
+
+  return data;
+};
+
+export default { getPetTasks, getPet, getPets, getPetList, deletePet, update };

--- a/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
+++ b/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
@@ -11,6 +11,7 @@ import {
   useDisclosure,
   useToast,
 } from "@chakra-ui/react";
+import axios from "axios";
 import { ChevronRightIcon } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -25,10 +26,11 @@ import PopupModal from "../../../components/common/PopupModal";
 import ProfilePhoto from "../../../components/common/ProfilePhoto";
 import SingleSelect from "../../../components/common/SingleSelect";
 import TextArea from "../../../components/common/TextArea";
-import { SexEnum } from "../../../types/PetTypes";
+import { PetRequestDTO, PetStatus, SexEnum } from "../../../types/PetTypes";
 import { AnimalTag, colorLevelMap } from "../../../types/TaskTypes";
 import {
   getDaysInMonth,
+  MONTH_NAME_TO_NUMBER,
   MONTH_NUMBER_TO_NAME,
 } from "../../../utils/CommonUtils";
 import QuitEditingModal from "./QuitEditingModal";
@@ -51,6 +53,10 @@ interface FormData {
   profilePhoto: string;
 }
 
+const colorLevelToNumber: Record<string, number> = Object.fromEntries(
+  Object.entries(colorLevelMap).map(([num, name]) => [name, Number(num)]),
+);
+
 const getSpayedNeuteredValue = (sex?: SexEnum, spayedNeutered?: boolean) => {
   if (spayedNeutered === undefined || spayedNeutered === null) {
     return "";
@@ -59,7 +65,7 @@ const getSpayedNeuteredValue = (sex?: SexEnum, spayedNeutered?: boolean) => {
     return spayedNeutered ? "Neutered" : "Unneutered";
   }
   // Must be female
-  return spayedNeutered ? "Spayed" : "Not spayed";
+  return spayedNeutered ? "Spayed" : "Unspayed";
 };
 
 // By default we give 31 days if no month is
@@ -111,6 +117,7 @@ const EditPetProfilePage = (): React.ReactElement => {
     string | undefined
   >(undefined);
   const [isUploading, setIsUploading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [page, setPage] = useState(1);
   const {
     isOpen: isDeleteConfirmModalOpen,
@@ -237,33 +244,159 @@ const EditPetProfilePage = (): React.ReactElement => {
       "medicalInfo",
     ]);
 
-    if (isValid) {
-      // TODO: Remove this and submit actual data to backend endpoint
-      // eslint-disable-next-line no-console
-      console.log({
+    if (!isValid) return;
+
+    // Build birthday string (YYYY-MM-DD) or undefined
+    let birthday: string | undefined;
+    if (
+      data.birthdayMonth &&
+      data.birthdayMonth !== "--" &&
+      data.birthdayDate &&
+      data.birthdayDate !== "--" &&
+      data.birthdayYear &&
+      data.birthdayYear !== "--"
+    ) {
+      const month = MONTH_NAME_TO_NUMBER[data.birthdayMonth]
+        .toString()
+        .padStart(2, "0");
+      const day = data.birthdayDate.padStart(2, "0");
+      birthday = `${data.birthdayYear}-${month}-${day}`;
+    }
+
+    // Convert neutered string to boolean or undefined
+    let neutered: boolean | undefined;
+    if (data.neutered === "Neutered" || data.neutered === "Spayed") {
+      neutered = true;
+    } else if (
+      data.neutered === "Unneutered" ||
+      data.neutered === "Unspayed"
+    ) {
+      neutered = false;
+    }
+
+    // Convert sex string to SexEnum or undefined
+    let sex: SexEnum | undefined;
+    if (data.sex === "Male") sex = SexEnum.MALE;
+    else if (data.sex === "Female") sex = SexEnum.FEMALE;
+
+    // Build careInfo only if at least one field has content
+    const careInfo =
+      data.safetyInfo || data.managementInfo || data.medicalInfo
+        ? {
+            safetyInfo: data.safetyInfo || undefined,
+            medicalInfo: data.medicalInfo || undefined,
+            managementInfo: data.managementInfo || undefined,
+          }
+        : undefined;
+
+    setSubmitting(true);
+    try {
+      // Fetch current pet to preserve its status
+      const currentPet = await PetAPIClient.getPet(petId);
+
+      const formattedData: PetRequestDTO = {
         name: data.name,
-        colourLevel: data.colourLevel,
-        animalTag: data.animalTag,
-        breed: data.breed,
-        weight: data.weight,
-        birthdayMonth: data.birthdayMonth,
-        birthdayDate: data.birthdayDate,
-        birthdayYear: data.birthdayYear,
-        sex: data.sex,
-        neutered: data.neutered,
-        safetyInfo: data.safetyInfo,
-        managementInfo: data.managementInfo,
-        medicalInfo: data.medicalInfo,
-        profilePhoto: localProfilePhoto,
+        colorLevel: colorLevelToNumber[data.colourLevel],
+        animalTag: data.animalTag as AnimalTag,
+        status: currentPet.status as PetStatus,
+        breed: data.breed || undefined,
+        weight: data.weight ? parseFloat(data.weight) : undefined,
+        birthday,
+        sex,
+        neutered,
+        photo:
+          localProfilePhoto && !localProfilePhoto.startsWith("data:")
+            ? localProfilePhoto
+            : currentPet.photo || undefined,
+        careInfo,
+      };
+      await PetAPIClient.update(petId, formattedData);
+
+      // Refetch updated pet and reset form
+      const updatedPet = await PetAPIClient.getPet(petId);
+      setLocalProfilePhoto(updatedPet.photo);
+
+      let updatedBirthdayYear: string | undefined;
+      let updatedBirthdayMonth: string | undefined;
+      let updatedBirthdayDate: string | undefined;
+      if (updatedPet.birthday) {
+        const [year, month, day] = updatedPet.birthday.split("-");
+        updatedBirthdayYear = year;
+        updatedBirthdayMonth = MONTH_NUMBER_TO_NAME[Number(month)];
+        updatedBirthdayDate = day;
+        setBirthdayDateOptions(
+          getBirthdayDateOptions(updatedBirthdayMonth, updatedBirthdayYear),
+        );
+      }
+
+      reset({
+        name: updatedPet.name,
+        colourLevel: colorLevelMap[updatedPet.colorLevel],
+        animalTag: updatedPet.animalTag,
+        breed: updatedPet.breed || "",
+        weight: updatedPet.weight?.toString() || "",
+        birthdayYear: updatedBirthdayYear,
+        birthdayMonth: updatedBirthdayMonth,
+        birthdayDate: updatedBirthdayDate,
+        sex: updatedPet.sex === SexEnum.MALE ? "Male" : updatedPet.sex === SexEnum.FEMALE ? "Female" : "",
+        neutered: getSpayedNeuteredValue(updatedPet.sex, updatedPet.neutered),
+        safetyInfo: updatedPet.careInfo?.safetyInfo || "",
+        managementInfo: updatedPet.careInfo?.managementInfo || "",
+        medicalInfo: updatedPet.careInfo?.medicalInfo || "",
+        profilePhoto: updatedPet.photo || "",
       });
 
       toast({
         title: "Success",
-        description: "Form data logged to console",
+        description: "Pet profile updated successfully",
         status: "success",
         duration: 3000,
         isClosable: true,
       });
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const status = error.response?.status;
+        if (status === 404) {
+          history.push("/not-found");
+          return;
+        }
+        if (status === 403) {
+          toast({
+            title: "Unauthorized",
+            description: "You do not have permission to update this pet",
+            status: "error",
+            duration: 3000,
+            isClosable: true,
+          });
+        } else if (status === 400) {
+          toast({
+            title: "Validation Error",
+            description:
+              error.response?.data || "Please check your input and try again",
+            status: "error",
+            duration: 3000,
+            isClosable: true,
+          });
+        } else {
+          toast({
+            title: "Error",
+            description: "Failed to update pet profile",
+            status: "error",
+            duration: 3000,
+            isClosable: true,
+          });
+        }
+      } else {
+        toast({
+          title: "Error",
+          description: "Failed to update pet profile",
+          status: "error",
+          duration: 3000,
+          isClosable: true,
+        });
+      }
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -803,8 +936,13 @@ const EditPetProfilePage = (): React.ReactElement => {
                   >
                     Previous
                   </Button>
-                  <Button variant="green" size="medium" type="submit">
-                    Save
+                  <Button
+                    variant="green"
+                    size="medium"
+                    type="submit"
+                    disabled={submitting}
+                  >
+                    {submitting ? "Saving..." : "Save"}
                   </Button>
                 </>
               )}

--- a/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
+++ b/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
@@ -197,9 +197,9 @@ const EditPetProfilePage = (): React.ReactElement => {
           animalTag: petData.animalTag,
           breed: petData.breed || "",
           weight: petData.weight?.toString() || "",
-          birthdayYear,
-          birthdayMonth,
-          birthdayDate,
+          birthdayYear: birthdayYear || "",
+          birthdayMonth: birthdayMonth || "",
+          birthdayDate: birthdayDate || "",
           sex: petData.sex === SexEnum.MALE ? "Male" : "Female",
           neutered: getSpayedNeuteredValue(petData.sex, petData.neutered),
           safetyInfo: petData.careInfo?.safetyInfo || "",
@@ -246,8 +246,8 @@ const EditPetProfilePage = (): React.ReactElement => {
 
     if (!isValid) return;
 
-    // Build birthday string (YYYY-MM-DD) or undefined
-    let birthday: string | undefined;
+    // Build birthday string (YYYY-MM-DD) or null
+    let birthday: string | null = null;
     if (
       data.birthdayMonth &&
       data.birthdayMonth !== "--" &&
@@ -263,28 +263,25 @@ const EditPetProfilePage = (): React.ReactElement => {
       birthday = `${data.birthdayYear}-${month}-${day}`;
     }
 
-    // Convert neutered string to boolean or undefined
-    let neutered: boolean | undefined;
+    // Convert neutered string to boolean or null
+    let neutered: boolean | null = null;
     if (data.neutered === "Neutered" || data.neutered === "Spayed") {
       neutered = true;
     } else if (data.neutered === "Unneutered" || data.neutered === "Unspayed") {
       neutered = false;
     }
 
-    // Convert sex string to SexEnum or undefined
+    // Convert sex string to SexEnum (sex is NOT NULL in DB, send undefined to keep existing value)
     let sex: SexEnum | undefined;
     if (data.sex === "Male") sex = SexEnum.MALE;
     else if (data.sex === "Female") sex = SexEnum.FEMALE;
 
-    // Build careInfo only if at least one field has content
-    const careInfo =
-      data.safetyInfo || data.managementInfo || data.medicalInfo
-        ? {
-            safetyInfo: data.safetyInfo || undefined,
-            medicalInfo: data.medicalInfo || undefined,
-            managementInfo: data.managementInfo || undefined,
-          }
-        : undefined;
+    // Build careInfo with null for blank fields
+    const careInfo = {
+      safetyInfo: data.safetyInfo || null,
+      medicalInfo: data.medicalInfo || null,
+      managementInfo: data.managementInfo || null,
+    };
 
     setSubmitting(true);
     try {
@@ -296,15 +293,15 @@ const EditPetProfilePage = (): React.ReactElement => {
         colorLevel: colorLevelToNumber[data.colourLevel],
         animalTag: data.animalTag as AnimalTag,
         status: currentPet.status as PetStatus,
-        breed: data.breed || undefined,
-        weight: data.weight ? parseFloat(data.weight) : undefined,
+        breed: data.breed || null,
+        weight: data.weight ? parseFloat(data.weight) : null,
         birthday,
         sex,
         neutered,
         photo:
           localProfilePhoto && !localProfilePhoto.startsWith("data:")
             ? localProfilePhoto
-            : currentPet.photo || undefined,
+            : currentPet.photo || null,
         careInfo,
       };
       await PetAPIClient.update(petId, formattedData);
@@ -332,9 +329,9 @@ const EditPetProfilePage = (): React.ReactElement => {
         animalTag: updatedPet.animalTag,
         breed: updatedPet.breed || "",
         weight: updatedPet.weight?.toString() || "",
-        birthdayYear: updatedBirthdayYear,
-        birthdayMonth: updatedBirthdayMonth,
-        birthdayDate: updatedBirthdayDate,
+        birthdayYear: updatedBirthdayYear || "",
+        birthdayMonth: updatedBirthdayMonth || "",
+        birthdayDate: updatedBirthdayDate || "",
         sex: (() => {
           if (updatedPet.sex === SexEnum.MALE) return "Male";
           if (updatedPet.sex === SexEnum.FEMALE) return "Female";

--- a/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
+++ b/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
@@ -267,10 +267,7 @@ const EditPetProfilePage = (): React.ReactElement => {
     let neutered: boolean | undefined;
     if (data.neutered === "Neutered" || data.neutered === "Spayed") {
       neutered = true;
-    } else if (
-      data.neutered === "Unneutered" ||
-      data.neutered === "Unspayed"
-    ) {
+    } else if (data.neutered === "Unneutered" || data.neutered === "Unspayed") {
       neutered = false;
     }
 
@@ -338,7 +335,11 @@ const EditPetProfilePage = (): React.ReactElement => {
         birthdayYear: updatedBirthdayYear,
         birthdayMonth: updatedBirthdayMonth,
         birthdayDate: updatedBirthdayDate,
-        sex: updatedPet.sex === SexEnum.MALE ? "Male" : updatedPet.sex === SexEnum.FEMALE ? "Female" : "",
+        sex: (() => {
+          if (updatedPet.sex === SexEnum.MALE) return "Male";
+          if (updatedPet.sex === SexEnum.FEMALE) return "Female";
+          return "";
+        })(),
         neutered: getSpayedNeuteredValue(updatedPet.sex, updatedPet.neutered),
         safetyInfo: updatedPet.careInfo?.safetyInfo || "",
         managementInfo: updatedPet.careInfo?.managementInfo || "",

--- a/frontend/src/features/pet-profile/pages/PetProfilePage.tsx
+++ b/frontend/src/features/pet-profile/pages/PetProfilePage.tsx
@@ -79,6 +79,7 @@ const PetProfilePage = (): React.ReactElement => {
         );
         setTasks(sortedTasks);
       } catch (err) {
+        // eslint-disable-next-line no-console
         console.error(err);
       }
     };

--- a/frontend/src/types/PetTypes.ts
+++ b/frontend/src/types/PetTypes.ts
@@ -75,4 +75,22 @@ export interface PetListItemDTO {
   animalTag: AnimalTag;
 }
 
+export interface PetRequestDTO {
+  animalTag: AnimalTag;
+  name: string;
+  colorLevel: number;
+  status: PetStatus;
+  breed?: string;
+  neutered?: boolean;
+  birthday?: string;
+  weight?: number;
+  sex?: SexEnum;
+  photo?: string;
+  careInfo?: {
+    safetyInfo?: string;
+    medicalInfo?: string;
+    managementInfo?: string;
+  };
+}
+
 export type PetListSections = Record<string, PetListItemDTO[]>;

--- a/frontend/src/types/PetTypes.ts
+++ b/frontend/src/types/PetTypes.ts
@@ -80,17 +80,17 @@ export interface PetRequestDTO {
   name: string;
   colorLevel: number;
   status: PetStatus;
-  breed?: string;
-  neutered?: boolean;
-  birthday?: string;
-  weight?: number;
+  breed?: string | null;
+  neutered?: boolean | null;
+  birthday?: string | null;
+  weight?: number | null;
   sex?: SexEnum;
-  photo?: string;
+  photo?: string | null;
   careInfo?: {
-    safetyInfo?: string;
-    medicalInfo?: string;
-    managementInfo?: string;
-  };
+    safetyInfo?: string | null;
+    medicalInfo?: string | null;
+    managementInfo?: string | null;
+  } | null;
 }
 
 export type PetListSections = Record<string, PetListItemDTO[]>;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Edit pet profile functionality](https://www.notion.so/uwblueprintexecs/Edit-Pet-Profile-Page-Functionality-30b10f3fb1dc80c5a8d3d52519193acf?source=copy_link)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Connected EditPetProfilePage form submission to PUT /pets/:petId backend endpoint
* Added PetAPIClient.update() method
* On success: refetches pet, resets form, shows toast
* Seems that pet profile photo upload does not work in backend, so I have left that out of the update for now (feel free to correct me though)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Edit a pet and verify change + toast + refetch occurs
2. Add safety/management/medical info to a pet that has none, verify it creates a row in the pet care info table
3. Try accessing /edit-pet-profile/:id as a volunteer (denied) and animal behaviourist (allowed)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* The ticket specified to send `undefined` for blank values, do note that this means they will not be cleared, as I believe backend treats `undefined` as "no change" 
* I think backend already supports null to clear fields, so if it makes more sense for design, we can send null to backend instead to clear nullable fields.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR