### PR TITLE
Center date selector

### DIFF
--- a/frontend/src/features/pet-profile/pages/PetProfilePage.tsx
+++ b/frontend/src/features/pet-profile/pages/PetProfilePage.tsx
@@ -22,6 +22,7 @@ import { TableColumn, TableHeader } from "../../../components/common/table";
 import { getPetTasksByDate } from "../../../APIClients/TaskAPIClient";
 import PetProfileTaskTableSection from "./PetProfileTaskTableSection";
 import CalendarDateSelector from "../../user-profile/components/CalendarDateSelector";
+import Button from "../../../components/common/Button";
 
 const PetProfilePage = (): React.ReactElement => {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
@@ -154,10 +155,16 @@ const PetProfilePage = (): React.ReactElement => {
           <Switch>
             <Route exact path={path}>
               <Flex flexDirection="column">
-                {canAddTask}
                 <CalendarDateSelector
                   selectedDate={selectedDate}
                   onChange={(date) => setSelectedDate(date)}
+                  rightAction={
+                    canAddTask ? (
+                      <Button variant="dark-blue" size="small">
+                        Add Task
+                      </Button>
+                    ) : undefined
+                  }
                 />
                 <Flex
                   backgroundColor="gray.50"

--- a/frontend/src/features/user-profile/components/CalendarDateSelector.tsx
+++ b/frontend/src/features/user-profile/components/CalendarDateSelector.tsx
@@ -9,6 +9,7 @@ import { MONTH_NUMBER_TO_NAME } from "../../../utils/CommonUtils";
 interface CalendarDateSelectorProps {
   selectedDate: Date;
   onChange: (date: Date) => void;
+  rightAction?: React.ReactNode;
 }
 
 const DAYS = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
@@ -39,6 +40,7 @@ function getStartOfWeek(date: Date) {
 const CalendarDateSelector: React.FC<CalendarDateSelectorProps> = ({
   selectedDate,
   onChange,
+  rightAction,
 }) => {
   const [visibleWeekStart, setVisibleWeekStart] = useState<Date>(() =>
     getStartOfWeek(selectedDate),
@@ -72,8 +74,8 @@ const CalendarDateSelector: React.FC<CalendarDateSelectorProps> = ({
 
   return (
     <Flex flexDirection="column" gap="1.5rem" width="100%">
-      <Flex alignItems="center" gap="1rem">
-        <Text style={textStyles.h3} margin="0">
+      <Flex alignItems="center" gap="1rem" justifyContent={rightAction ? "space-between" : "flex-start"}>
+        <Text style={textStyles.h3} margin="0" flex={rightAction ? "1" : undefined}>
           {/* getMonth is zero-indexed, so we add one */}
           {MONTH_NUMBER_TO_NAME[visibleWeekStart.getMonth() + 1]}{" "}
           {visibleWeekStart.getFullYear()}
@@ -108,6 +110,7 @@ const CalendarDateSelector: React.FC<CalendarDateSelectorProps> = ({
             size="sm"
           />
         </Flex>
+        {rightAction && <Flex flex="1" justifyContent="flex-end">{rightAction}</Flex>}
       </Flex>
 
       <Flex justifyContent="space-between" gap="2rem">


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Calendar Fix](https://www.notion.so/uwblueprintexecs/Calendar-Fix-32f10f3fb1dc8022b241e1d7a8123a99?source=copy_link)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
<img width="2823" height="1593" alt="image" src="https://github.com/user-attachments/assets/476db3af-15d4-4ed5-bea2-bc9c66d65b2d" />


* CalendarDateSelector.tsx now takes a `rightAction` ReactNode, so it becomes centered if we pass in an "Add Task" button (this only passes if canAddTask is true, but this evaluates to true if the user is admin/behaviourist, which is required to see the pet profile page anyway)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to /pet-profile page and verify the date selector is centered
2. Also verify the date selector behaviour is not changed on user profile page


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR