### PR TITLE
Fix user profile photo loading

### DIFF
--- a/frontend/src/features/user-management/pages/UserManagementPage.tsx
+++ b/frontend/src/features/user-management/pages/UserManagementPage.tsx
@@ -65,7 +65,20 @@ const UserManagementPage = (): React.ReactElement => {
       const fetchedUsers = await UserAPIClient.get();
 
       if (fetchedUsers != null) {
-        setUsers(fetchedUsers);
+        const usersWithPhotoUrls = await Promise.all(
+          fetchedUsers.map(async (user) => {
+            if (user.profilePhoto) {
+              try {
+                const url = await UserAPIClient.getProfilePhotoUrl(user.id);
+                return { ...user, profilePhoto: url };
+              } catch {
+                return { ...user, profilePhoto: undefined };
+              }
+            }
+            return user;
+          })
+        );
+        setUsers(usersWithPhotoUrls);
       }
     } catch (error) {
       setErrorMessage(`${error}`);

--- a/frontend/src/features/user-profile/pages/UserProfilePage.tsx
+++ b/frontend/src/features/user-profile/pages/UserProfilePage.tsx
@@ -13,6 +13,9 @@ const ProfilePage = (): React.ReactElement => {
   const params = useParams<{ id: string }>();
   const userId = Number(params.id);
   const [userData, setUserData] = useState<User | null>(null);
+  const [profilePhotoUrl, setProfilePhotoUrl] = useState<string | undefined>(
+    undefined,
+  );
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const history = useHistory();
   const { authenticatedUser } = useContext(AuthContext);
@@ -35,6 +38,15 @@ const ProfilePage = (): React.ReactElement => {
           }
 
           setUserData(data);
+
+          if (data.profilePhoto) {
+            try {
+              const url = await UserAPIClient.getProfilePhotoUrl(data.id);
+              setProfilePhotoUrl(url);
+            } catch (error) {
+              setProfilePhotoUrl(undefined);
+            }
+          }
         } catch (error) {
           // console.error(`Failed to fetch user ${userId}:`, error);
           history.push("/not-found");
@@ -54,7 +66,7 @@ const ProfilePage = (): React.ReactElement => {
             id={userData.id}
             firstName={userData.firstName}
             lastName={userData.lastName}
-            profilePhoto={userData.profilePhoto}
+            profilePhoto={profilePhotoUrl}
             email={userData.email}
             phoneNumber={userData.phoneNumber}
             role={userData.role}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Profile Photo Fix](https://www.notion.so/uwblueprintexecs/Profile-Photo-Fix-32d10f3fb1dc8025bbb9cba0f5eea561)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated the User Profile page to call `UserAPIClient.getProfilePhotoUrl` to get the user's `profilePhotoUrl` to render in the User Profile sidebar


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to the user profile page [http://localhost:3000/profile/1](http://localhost:3000/profile/1)
2. If you have no profile photo uploaded, upload a profile photo by clicking on the pencil icon and editing your profile picture on the `VolunteerViewEditUserProfilePage`
3. On the user profile page, you should see your uploaded profile photo

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Verify that the user profile photo is correctly loaded

<img width="1792" height="1120" alt="Screenshot 2026-03-31 at 9 24 13 PM" src="https://github.com/user-attachments/assets/aa107717-e469-4ea7-89ec-e5711d8460bd" />

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR