### PR TITLE
Pin Yarn version and use frozen-lockfile in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Node.js dependencies
         if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.typescript-backend == 'true'
-        run: yarn --cwd ./frontend --prefer-offline && yarn --cwd ./backend/typescript --prefer-offline
+        run: yarn --cwd ./frontend --frozen-lockfile --prefer-offline && yarn --cwd ./backend/typescript --frozen-lockfile --prefer-offline
 
       - name: Lint frontend
         if: steps.changes.outputs.frontend == 'true'

--- a/backend/typescript/package.json
+++ b/backend/typescript/package.json
@@ -2,6 +2,7 @@
   "name": "typescript-backend",
   "version": "1.0.0",
   "description": "",
+  "packageManager": "yarn@1.22.22",
   "main": "server.ts",
   "scripts": {
     "test": "jest --runInBand --forceExit --detectOpenHandles",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "@apollo/client": "^3.3.16",
     "@chakra-ui/icons": "^2.2.4",


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
N/A — internal CI/tooling hardening (no Notion ticket).

## Implementation description
* Adds `--frozen-lockfile` to the `yarn install` step in the lint workflow so CI **fails loudly** if `yarn.lock` would change, instead of silently allowing a rewritten lockfile through.
* Pins the Yarn version via `"packageManager": "yarn@1.22.22"` in both `frontend/package.json` and `backend/typescript/package.json` so contributors stop drifting across Yarn 1.22.x patch versions.
* **Why:** recent PRs picked up large, dependency-free `yarn.lock` diffs (hundreds of reordered lines). Root cause was a `yarn install` run under a different Yarn patch than generated the lockfile, re-serializing it; with no `--frozen-lockfile` and no pinned version, nothing stopped it. This was not caused by the linter.

## Steps to test
1. Open a PR (or push) that touches `frontend/**` or `backend/typescript/**` and confirm the "Lint codebase" workflow runs.
2. Confirm the install step now runs with `--frozen-lockfile` and the lint job passes.
3. Negative case: locally run `yarn --cwd ./frontend --frozen-lockfile` after manually editing a dependency in `package.json` without updating the lockfile → it should error, which is the guardrail working.

## What should reviewers focus on?
* Whether CI passes with `--frozen-lockfile` on the **current** `main` lockfiles. If it fails, the committed lockfile is already out of sync and needs a one-time normalization (`yarn install` with the pinned version) in a follow-up commit — flagging so we watch the run.
* Whether we should also add a `corepack enable` step so CI uses the exact pinned Yarn (left out here to keep the change minimal).

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR