### PR TITLE
implement start button logic

### DIFF
--- a/frontend/src/APIClients/TaskAPIClient.ts
+++ b/frontend/src/APIClients/TaskAPIClient.ts
@@ -115,6 +115,22 @@ const assignUser = async (taskId: number, userId: number): Promise<void> => {
   }
 };
 
+const startTask = async (taskId: number, startTime: string): Promise<void> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+  try {
+    await baseAPIClient.patch(
+      `/tasks/${taskId}/start`,
+      { startTime },
+      { headers: { Authorization: bearerToken } },
+    );
+  } catch (error) {
+    throw new Error(`Failed to assign user: ${error}`);
+  }
+};
+
 const createTask = async (payload: {
   userId: number | null;
   petId: number;
@@ -176,6 +192,7 @@ export default {
   getUserTasks,
   getPetTasks,
   assignUser,
+  startTask,
   createTask,
   createRecurringTask,
 };

--- a/frontend/src/APIClients/TaskAPIClient.ts
+++ b/frontend/src/APIClients/TaskAPIClient.ts
@@ -127,7 +127,7 @@ const startTask = async (taskId: number, startTime: string): Promise<void> => {
       { headers: { Authorization: bearerToken } },
     );
   } catch (error) {
-    throw new Error(`Failed to assign user: ${error}`);
+    throw new Error(`Failed to start task: ${error}`);
   }
 };
 

--- a/frontend/src/features/pet-profile/components/TaskDetailsModal.tsx
+++ b/frontend/src/features/pet-profile/components/TaskDetailsModal.tsx
@@ -321,6 +321,28 @@ const TaskDetailsModal = ({
     return "Recurring";
   };
 
+  const handleStart = async () => {
+    try {
+      await TaskAPIClient.startTask(taskId, new Date().toISOString());
+      const updated = await TaskAPIClient.getTask(taskId);
+      setTaskData(updated);
+      toast({
+        title: "Task started",
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (e) {
+      toast({
+        title: "Error",
+        description: "Failed to start task",
+        status: "error",
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+  };
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
@@ -520,6 +542,7 @@ const TaskDetailsModal = ({
                         size="medium"
                         width="100%"
                         disabled={isPetOccupied || hasInProgressTask}
+                        onClick={handleStart}
                       >
                         Start
                       </Button>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Start button wiring](https://app.notion.com/p/uwblueprintexecs/Start-button-wiring-37710f3fb1dc80359c9bd6ec4a7d3853)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Wrote startTask function in TaskClientAPI to connect to PATCH /tasks/:id/start  endpoint
* Wired Start button to call on PATCH /tasks/:id/start and show success/toast errors


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.Log in as a volunteer 
2.Add a new task with no startTime scheduled for today (either insert it into the database, or log in as an admin first and assign a task to the volunteer account)
3.Click on the task you added. Alternatively, you may have to hardcode TaskDetailModal if the branch that integrates it is not merged yet.
4.Click start. Verify that success toast shows and it changes the modal to show the restart and complete buttons. Check the database to verify that it shows start time as the current time.
5.Either delete the startTime in the database or make a new task with no startTime scheduled for today. Go to Network and go Offline, and click the start button. Verify that the failure toast shows.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Make sure the startTime persists in the database please


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR