### PR TITLE
S26/Erin/optional sex field

### DIFF
--- a/backend/typescript/migrations/2026.06.09T12.00.00.allow-pet-sex-null.ts
+++ b/backend/typescript/migrations/2026.06.09T12.00.00.allow-pet-sex-null.ts
@@ -14,9 +14,13 @@ export const up: Migration = async ({ context: sequelize }) => {
 
 export const down: Migration = async ({ context: sequelize }) => {
   const queryInterface = sequelize.getQueryInterface();
+  // Before restoring NOT NULL, fill any nulls introduced after the up migration ran
+  await queryInterface.sequelize.query(
+    `UPDATE ${TABLE_NAME} SET sex = 'F' WHERE sex IS NULL;`,
+  );
   // Revert: set sex to NOT NULL and add default 'F'
   await queryInterface.sequelize.query(
-    `ALTER TABLE ${TABLE_NAME} 
+    `ALTER TABLE ${TABLE_NAME}
       ALTER COLUMN sex SET DEFAULT 'F',
       ALTER COLUMN sex SET NOT NULL;`,
   );

--- a/backend/typescript/migrations/2026.06.09T12.00.00.allow-pet-sex-null.ts
+++ b/backend/typescript/migrations/2026.06.09T12.00.00.allow-pet-sex-null.ts
@@ -1,0 +1,23 @@
+import { Migration } from "../umzug";
+
+const TABLE_NAME = "pets";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  const queryInterface = sequelize.getQueryInterface();
+  // Allow sex column to be nullable and remove any default value
+  await queryInterface.sequelize.query(
+    `ALTER TABLE ${TABLE_NAME} 
+      ALTER COLUMN sex DROP NOT NULL,
+      ALTER COLUMN sex DROP DEFAULT;`,
+  );
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  const queryInterface = sequelize.getQueryInterface();
+  // Revert: set sex to NOT NULL and add default 'F'
+  await queryInterface.sequelize.query(
+    `ALTER TABLE ${TABLE_NAME} 
+      ALTER COLUMN sex SET DEFAULT 'F',
+      ALTER COLUMN sex SET NOT NULL;`,
+  );
+};

--- a/backend/typescript/models/pet.model.ts
+++ b/backend/typescript/models/pet.model.ts
@@ -43,7 +43,7 @@ export default class Pet extends Model {
   neutered?: boolean;
 
   @Column({ type: DataType.ENUM("M", "F") })
-  sex?: Sex;
+  sex?: Sex | null;
 
   @Column({})
   photo?: string;

--- a/backend/typescript/services/interfaces/petService.ts
+++ b/backend/typescript/services/interfaces/petService.ts
@@ -15,7 +15,7 @@ export interface PetRequestDTO {
   neutered?: boolean;
   birthday?: string;
   weight?: number;
-  sex?: Sex;
+  sex?: Sex | null;
   photo?: string | null;
   careInfo?: {
     safetyInfo?: string;
@@ -34,7 +34,7 @@ export interface PetResponseDTO {
   neutered?: boolean;
   age?: number;
   weight?: number;
-  sex?: Sex;
+  sex?: Sex | null;
   photo?: string;
   careInfo?: {
     id: number;

--- a/frontend/src/APIClients/PetAPIClient.ts
+++ b/frontend/src/APIClients/PetAPIClient.ts
@@ -168,7 +168,11 @@ const update = async (petId: number, formData: PetRequestDTO): Promise<Pet> => {
   return data;
 };
 
-const uploadProfilePhoto = async (file: File, petId: number, oldStoragePath?: string): Promise<string> => {
+const uploadProfilePhoto = async (
+  file: File,
+  petId: number,
+  oldStoragePath?: string,
+): Promise<string> => {
   const bearerToken = `Bearer ${getLocalStorageObjProperty(
     AUTHENTICATED_USER_KEY,
     "accessToken",
@@ -181,19 +185,22 @@ const uploadProfilePhoto = async (file: File, petId: number, oldStoragePath?: st
     if (oldStoragePath) {
       formData.append("oldStoragePath", oldStoragePath);
     }
-    const res = await baseAPIClient.post(`/pets/${petId}/profile-photo/upload`,
+    const res = await baseAPIClient.post(
+      `/pets/${petId}/profile-photo/upload`,
       formData,
       {
-      headers: { Authorization: bearerToken },
-    });
+        headers: { Authorization: bearerToken },
+      },
+    );
 
-    if (typeof res.data.storagePath !== "string") throw new Error(`Failed to get profile photo url`);
+    if (typeof res.data.storagePath !== "string")
+      throw new Error(`Failed to get profile photo url`);
 
     return res.data.storagePath;
   } catch (error) {
     throw new Error(`Failed to set new profile photo: ${error}`);
   }
-}
+};
 
 const setDefaultProfilePhoto = async (petId: number) => {
   const bearerToken = `Bearer ${getLocalStorageObjProperty(
@@ -201,15 +208,19 @@ const setDefaultProfilePhoto = async (petId: number) => {
     "accessToken",
   )}`;
   try {
-    const res = await baseAPIClient.post(`/pets/${petId}/profile-photo/default`, {
-      headers: { Authorization: bearerToken },
-    });
+    const res = await baseAPIClient.post(
+      `/pets/${petId}/profile-photo/default`,
+      {
+        headers: { Authorization: bearerToken },
+      },
+    );
 
-    if (res.status !== 200) throw new Error(`Failed to set default profile photo`);
+    if (res.status !== 200)
+      throw new Error(`Failed to set default profile photo`);
   } catch (error) {
     throw new Error(`Failed to set default profile photo: ${error}`);
   }
-}
+};
 
 const getProfilePhotoUrl = async (petId: number): Promise<string> => {
   const bearerToken = `Bearer ${getLocalStorageObjProperty(
@@ -221,12 +232,24 @@ const getProfilePhotoUrl = async (petId: number): Promise<string> => {
       headers: { Authorization: bearerToken },
     });
 
-    if (typeof res.data.url !== "string") throw new Error(`Failed to get profile photo url`);
+    if (typeof res.data.url !== "string")
+      throw new Error(`Failed to get profile photo url`);
 
     return res.data.url;
   } catch (error) {
     throw new Error(`Failed to get profile photo url: ${error}`);
   }
-}
+};
 
-export default { getPetTasks, getPet, getPets, getPetList, getProfilePhotoUrl, setDefaultProfilePhoto, uploadProfilePhoto, createPet, update, deletePet };
+export default {
+  getPetTasks,
+  getPet,
+  getPets,
+  getPetList,
+  getProfilePhotoUrl,
+  setDefaultProfilePhoto,
+  uploadProfilePhoto,
+  createPet,
+  update,
+  deletePet,
+};

--- a/frontend/src/features/pet-profile/components/PetProfileSidebar.tsx
+++ b/frontend/src/features/pet-profile/components/PetProfileSidebar.tsx
@@ -39,7 +39,7 @@ export interface PetProfileSidebarProps {
   birthday?: string;
   weight?: number;
   neutered?: boolean;
-  sex?: SexEnum;
+  sex?: SexEnum | null;
   photo?: string;
   careInfo?: {
     safetyInfo?: string;
@@ -72,8 +72,8 @@ const getSpayStatusLabel = (spayedNeutered?: boolean) => {
   return spayedNeutered ? "Spayed" : "Not spayed";
 };
 
-const getSexLabel = (sex?: SexEnum) => {
-  if (sex === undefined) return "Unknown sex";
+const getSexLabel = (sex?: SexEnum | null) => {
+  if (sex === undefined || sex === null) return "Unknown sex";
   return sex === SexEnum.MALE ? "Male" : "Female";
 };
 
@@ -243,11 +243,13 @@ function PetProfileSidebar({
               width="100%"
               height="100%"
             >
-              <Image
-                src={sex === SexEnum.MALE ? MaleIcon : FemaleIcon}
-                alt="sex"
-                boxSize="1.2rem"
-              />
+              {sex !== null && sex !== undefined && (
+                <Image
+                  src={sex === SexEnum.MALE ? MaleIcon : FemaleIcon}
+                  alt="sex"
+                  boxSize="1.2rem"
+                />
+              )}
               <Text
                 textStyle="body"
                 fontSize="1rem"

--- a/frontend/src/features/pet-profile/components/PetProfileSidebar.tsx
+++ b/frontend/src/features/pet-profile/components/PetProfileSidebar.tsx
@@ -73,7 +73,7 @@ const getSpayStatusLabel = (spayedNeutered?: boolean) => {
 };
 
 const getSexLabel = (sex?: SexEnum | null) => {
-  if (sex === undefined || sex === null) return "Unknown sex";
+  if (sex === undefined || sex === null) return "--";
   return sex === SexEnum.MALE ? "Male" : "Female";
 };
 
@@ -243,13 +243,11 @@ function PetProfileSidebar({
               width="100%"
               height="100%"
             >
-              {sex !== null && sex !== undefined && (
-                <Image
-                  src={sex === SexEnum.MALE ? MaleIcon : FemaleIcon}
-                  alt="sex"
-                  boxSize="1.2rem"
-                />
-              )}
+              <Image
+                src={sex === SexEnum.FEMALE ? FemaleIcon : MaleIcon}
+                alt="sex"
+                boxSize="1.2rem"
+              />
               <Text
                 textStyle="body"
                 fontSize="1rem"

--- a/frontend/src/features/pet-profile/pages/AddPetForm.tsx
+++ b/frontend/src/features/pet-profile/pages/AddPetForm.tsx
@@ -15,7 +15,7 @@ import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useHistory } from "react-router-dom";
 import PetAPIClient from "../../../APIClients/PetAPIClient";
-import { PencilIcon } from "../../../assets/icons";
+import { FemaleIcon, MaleIcon, PencilIcon } from "../../../assets/icons";
 import Button from "../../../components/common/Button";
 import ColourStarIcon from "../../../components/common/ColourStarIcon";
 import Input from "../../../components/common/Input";
@@ -308,6 +308,11 @@ const AddPetForm = (): React.ReactElement => {
     ),
   ];
   const sexOptions = ["--", "Male", "Female"];
+  const sexIcons = [
+    <Image key="unknown" src={MaleIcon} boxSize="1.2rem" />,
+    <Image key="male" src={MaleIcon} boxSize="1.2rem" />,
+    <Image key="female" src={FemaleIcon} boxSize="1.2rem" />,
+  ];
   const spayedNeuteredOptions = [
     "--",
     "Neutered",

--- a/frontend/src/features/pet-profile/pages/AddPetForm.tsx
+++ b/frontend/src/features/pet-profile/pages/AddPetForm.tsx
@@ -15,7 +15,7 @@ import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useHistory } from "react-router-dom";
 import PetAPIClient from "../../../APIClients/PetAPIClient";
-import { FemaleIcon, MaleIcon, PencilIcon } from "../../../assets/icons";
+import { PencilIcon } from "../../../assets/icons";
 import Button from "../../../components/common/Button";
 import ColourStarIcon from "../../../components/common/ColourStarIcon";
 import Input from "../../../components/common/Input";
@@ -308,11 +308,6 @@ const AddPetForm = (): React.ReactElement => {
     ),
   ];
   const sexOptions = ["--", "Male", "Female"];
-  const sexIcons = [
-    <Image key="unknown" src={MaleIcon} boxSize="1.2rem" />,
-    <Image key="male" src={MaleIcon} boxSize="1.2rem" />,
-    <Image key="female" src={FemaleIcon} boxSize="1.2rem" />,
-  ];
   const spayedNeuteredOptions = [
     "--",
     "Neutered",

--- a/frontend/src/features/pet-profile/pages/AddTaskForm.tsx
+++ b/frontend/src/features/pet-profile/pages/AddTaskForm.tsx
@@ -180,7 +180,7 @@ const AddTaskForm = ({
   const handlePreviousPage = async () => {
     setCurrentStep(currentStep - 1);
   };
-  
+
   return (
     <Flex flexDirection="column" width="100%" gap="1.5rem" paddingBottom="1rem">
       {/* Back Button */}

--- a/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
+++ b/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
@@ -70,7 +70,7 @@ const getSpayedNeuteredValue = (
   if (spayedNeutered === undefined || spayedNeutered === null) {
     return "";
   }
-  if (sex === undefined || sex === SexEnum.MALE) {
+  if (sex === undefined || sex === null || sex === SexEnum.MALE) {
     return spayedNeutered ? "Neutered" : "Unneutered";
   }
   // Must be female

--- a/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
+++ b/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
@@ -58,7 +58,10 @@ const colorLevelToNumber: Record<string, number> = Object.fromEntries(
   Object.entries(colorLevelMap).map(([num, name]) => [name, Number(num)]),
 );
 
-const getSpayedNeuteredValue = (sex?: SexEnum, spayedNeutered?: boolean) => {
+const getSpayedNeuteredValue = (
+  sex?: SexEnum | null,
+  spayedNeutered?: boolean | null,
+) => {
   if (spayedNeutered === undefined || spayedNeutered === null) {
     return "";
   }
@@ -205,7 +208,12 @@ const EditPetProfilePage = (): React.ReactElement => {
           birthdayYear: birthdayYear || "",
           birthdayMonth: birthdayMonth || "",
           birthdayDate: birthdayDate || "",
-          sex: petData.sex === SexEnum.MALE ? "Male" : "Female",
+          sex:
+            petData.sex === SexEnum.MALE
+              ? "Male"
+              : petData.sex === SexEnum.FEMALE
+              ? "Female"
+              : "",
           neutered: getSpayedNeuteredValue(petData.sex, petData.neutered),
           safetyInfo: petData.careInfo?.safetyInfo || "",
           managementInfo: petData.careInfo?.managementInfo || "",
@@ -287,10 +295,12 @@ const EditPetProfilePage = (): React.ReactElement => {
       neutered = false;
     }
 
-    // Convert sex string to SexEnum (sex is NOT NULL in DB, send undefined to keep existing value)
-    let sex: SexEnum | undefined;
+    // Convert sex string to SexEnum. Send `null` when user clears the field
+    // so backend will set the DB value to NULL.
+    let sex: SexEnum | null;
     if (data.sex === "Male") sex = SexEnum.MALE;
     else if (data.sex === "Female") sex = SexEnum.FEMALE;
+    else sex = null;
 
     // Build careInfo with null for blank fields
     const careInfo = {

--- a/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
+++ b/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
@@ -17,7 +17,7 @@ import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useHistory, useParams } from "react-router-dom";
 import PetAPIClient from "../../../APIClients/PetAPIClient";
-import { FemaleIcon, MaleIcon, PencilIcon } from "../../../assets/icons";
+import { PencilIcon } from "../../../assets/icons";
 import Button from "../../../components/common/Button";
 import ColourStarIcon from "../../../components/common/ColourStarIcon";
 import Input from "../../../components/common/Input";
@@ -26,7 +26,12 @@ import PopupModal from "../../../components/common/PopupModal";
 import ProfilePhoto from "../../../components/common/ProfilePhoto";
 import SingleSelect from "../../../components/common/SingleSelect";
 import TextArea from "../../../components/common/TextArea";
-import { PetRequestDTO, PetStatus, SexEnum, Pet } from "../../../types/PetTypes";
+import {
+  PetRequestDTO,
+  PetStatus,
+  SexEnum,
+  Pet,
+} from "../../../types/PetTypes";
 import { AnimalTag, colorLevelMap } from "../../../types/TaskTypes";
 import {
   getDaysInMonth,
@@ -122,9 +127,11 @@ const EditPetProfilePage = (): React.ReactElement => {
   >(undefined);
   const [submitting, setSubmitting] = useState(false);
   const [page, setPage] = useState(1);
-  const [pet, setPet] = useState<Pet | undefined>(undefined)
+  const [pet, setPet] = useState<Pet | undefined>(undefined);
   const [editPetPhoto, setEditPetPhoto] = useState(false);
-  const [newPetProfilePhoto, setNewPetProfilePhoto] = useState<File | undefined>(undefined)
+  const [newPetProfilePhoto, setNewPetProfilePhoto] = useState<
+    File | undefined
+  >(undefined);
   const {
     isOpen: isDeleteConfirmModalOpen,
     onOpen: openDeleteConfirmModal,
@@ -180,7 +187,7 @@ const EditPetProfilePage = (): React.ReactElement => {
           const photoUrl = await PetAPIClient.getProfilePhotoUrl(petData.id);
           setLocalProfilePhoto(photoUrl);
         }
-        setPet(petData)
+        setPet(petData);
         let birthdayYear: string | undefined;
         let birthdayMonth: string | undefined;
         let birthdayDate: string | undefined;
@@ -208,12 +215,11 @@ const EditPetProfilePage = (): React.ReactElement => {
           birthdayYear: birthdayYear || "",
           birthdayMonth: birthdayMonth || "",
           birthdayDate: birthdayDate || "",
-          sex:
-            petData.sex === SexEnum.MALE
-              ? "Male"
-              : petData.sex === SexEnum.FEMALE
-              ? "Female"
-              : "--",
+          sex: (() => {
+            if (petData.sex === SexEnum.MALE) return "Male";
+            if (petData.sex === SexEnum.FEMALE) return "Female";
+            return "--";
+          })(),
           neutered: getSpayedNeuteredValue(petData.sex, petData.neutered),
           safetyInfo: petData.careInfo?.safetyInfo || "",
           managementInfo: petData.careInfo?.managementInfo || "",
@@ -240,15 +246,15 @@ const EditPetProfilePage = (): React.ReactElement => {
   }, [selectedBirthdayMonth, selectedBirthdayYear]);
 
   const handleEditPetPhoto = (file: File | null) => {
-    setEditPetPhoto(false)
+    setEditPetPhoto(false);
     if (file) {
-      setNewPetProfilePhoto(file)
+      setNewPetProfilePhoto(file);
       const preview = URL.createObjectURL(file);
       setLocalProfilePhoto(preview); // update UI preview
     } else {
       setLocalProfilePhoto(undefined); // default case
     }
-  }
+  };
 
   const onSubmit = async (data: FormData) => {
     // Only allow a user to progress if they have resolved all errors
@@ -331,7 +337,7 @@ const EditPetProfilePage = (): React.ReactElement => {
         careInfo,
       };
       await PetAPIClient.update(petId, formattedData);
-      
+
       // Submit the pet profile photo
       if (newPetProfilePhoto) {
         await PetAPIClient.uploadProfilePhoto(
@@ -516,11 +522,6 @@ const EditPetProfilePage = (): React.ReactElement => {
     ),
   ];
   const sexOptions = ["--", "Male", "Female"];
-  const sexIcons = [
-    <Image key="unknown" src={MaleIcon} boxSize="1.2rem" />,
-    <Image key="male" src={MaleIcon} boxSize="1.2rem" />,
-    <Image key="female" src={FemaleIcon} boxSize="1.2rem" />,
-  ];
   const spayedNeuteredOptions = [
     "--",
     "Neutered",
@@ -619,14 +620,18 @@ const EditPetProfilePage = (): React.ReactElement => {
                         src={PencilIcon}
                         alt="edit"
                         style={{ stroke: "black" }}
-                        onClick={() => {setEditPetPhoto(true)}}
+                        onClick={() => {
+                          setEditPetPhoto(true);
+                        }}
                       />
-                      <ProfilePhotoModal 
-                      isOpen={editPetPhoto}
-                      profilePhoto={localProfilePhoto}
-                      onClose={() => { setEditPetPhoto(false) }}
-                      onConfirm={handleEditPetPhoto}
-                      type="pet"
+                      <ProfilePhotoModal
+                        isOpen={editPetPhoto}
+                        profilePhoto={localProfilePhoto}
+                        onClose={() => {
+                          setEditPetPhoto(false);
+                        }}
+                        onConfirm={handleEditPetPhoto}
+                        type="pet"
                       />
                     </Flex>
                   </Flex>

--- a/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
+++ b/frontend/src/features/pet-profile/pages/EditPetProfilePage.tsx
@@ -17,7 +17,7 @@ import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useHistory, useParams } from "react-router-dom";
 import PetAPIClient from "../../../APIClients/PetAPIClient";
-import { PencilIcon } from "../../../assets/icons";
+import { FemaleIcon, MaleIcon, PencilIcon } from "../../../assets/icons";
 import Button from "../../../components/common/Button";
 import ColourStarIcon from "../../../components/common/ColourStarIcon";
 import Input from "../../../components/common/Input";
@@ -213,7 +213,7 @@ const EditPetProfilePage = (): React.ReactElement => {
               ? "Male"
               : petData.sex === SexEnum.FEMALE
               ? "Female"
-              : "",
+              : "--",
           neutered: getSpayedNeuteredValue(petData.sex, petData.neutered),
           safetyInfo: petData.careInfo?.safetyInfo || "",
           managementInfo: petData.careInfo?.managementInfo || "",
@@ -375,7 +375,7 @@ const EditPetProfilePage = (): React.ReactElement => {
         sex: (() => {
           if (updatedPet.sex === SexEnum.MALE) return "Male";
           if (updatedPet.sex === SexEnum.FEMALE) return "Female";
-          return "";
+          return "--";
         })(),
         neutered: getSpayedNeuteredValue(updatedPet.sex, updatedPet.neutered),
         safetyInfo: updatedPet.careInfo?.safetyInfo || "",
@@ -516,6 +516,11 @@ const EditPetProfilePage = (): React.ReactElement => {
     ),
   ];
   const sexOptions = ["--", "Male", "Female"];
+  const sexIcons = [
+    <Image key="unknown" src={MaleIcon} boxSize="1.2rem" />,
+    <Image key="male" src={MaleIcon} boxSize="1.2rem" />,
+    <Image key="female" src={FemaleIcon} boxSize="1.2rem" />,
+  ];
   const spayedNeuteredOptions = [
     "--",
     "Neutered",

--- a/frontend/src/features/pet-profile/pages/PetProfilePage.tsx
+++ b/frontend/src/features/pet-profile/pages/PetProfilePage.tsx
@@ -62,7 +62,9 @@ const PetProfilePage = (): React.ReactElement => {
     authenticatedUser?.role === UserRoles.BEHAVIOURIST;
 
   const [petData, setPetData] = useState<Pet | null>(null);
-  const [profilePhoto, setProfilePhoto] = useState<string | undefined>(undefined);
+  const [profilePhoto, setProfilePhoto] = useState<string | undefined>(
+    undefined,
+  );
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {

--- a/frontend/src/features/user-management/pages/UserManagementPage.tsx
+++ b/frontend/src/features/user-management/pages/UserManagementPage.tsx
@@ -76,7 +76,7 @@ const UserManagementPage = (): React.ReactElement => {
               }
             }
             return user;
-          })
+          }),
         );
         setUsers(usersWithPhotoUrls);
       }

--- a/frontend/src/features/user-profile/components/CalendarDateSelector.tsx
+++ b/frontend/src/features/user-profile/components/CalendarDateSelector.tsx
@@ -74,8 +74,16 @@ const CalendarDateSelector: React.FC<CalendarDateSelectorProps> = ({
 
   return (
     <Flex flexDirection="column" gap="1.5rem" width="100%">
-      <Flex alignItems="center" gap="1rem" justifyContent={rightAction ? "space-between" : "flex-start"}>
-        <Text style={textStyles.h3} margin="0" flex={rightAction ? "1" : undefined}>
+      <Flex
+        alignItems="center"
+        gap="1rem"
+        justifyContent={rightAction ? "space-between" : "flex-start"}
+      >
+        <Text
+          style={textStyles.h3}
+          margin="0"
+          flex={rightAction ? "1" : undefined}
+        >
           {/* getMonth is zero-indexed, so we add one */}
           {MONTH_NUMBER_TO_NAME[visibleWeekStart.getMonth() + 1]}{" "}
           {visibleWeekStart.getFullYear()}
@@ -110,7 +118,11 @@ const CalendarDateSelector: React.FC<CalendarDateSelectorProps> = ({
             size="sm"
           />
         </Flex>
-        {rightAction && <Flex flex="1" justifyContent="flex-end">{rightAction}</Flex>}
+        {rightAction && (
+          <Flex flex="1" justifyContent="flex-end">
+            {rightAction}
+          </Flex>
+        )}
       </Flex>
 
       <Flex justifyContent="space-between" gap="2rem">

--- a/frontend/src/features/user-profile/components/ProfilePhotoModal.tsx
+++ b/frontend/src/features/user-profile/components/ProfilePhotoModal.tsx
@@ -19,7 +19,7 @@ type ModalView = "menu" | "upload" | "preview";
 interface ProfilePhotoModalProps {
   isOpen: boolean;
   profilePhoto: string | undefined;
-  type: "pet" | "user"
+  type: "pet" | "user";
   onClose?: () => void;
   onConfirm?: (file: File | null) => void;
 }

--- a/frontend/src/types/PetTypes.ts
+++ b/frontend/src/types/PetTypes.ts
@@ -22,7 +22,7 @@ export interface Pet {
   age?: number;
   birthday?: string;
   weight?: number;
-  sex?: SexEnum;
+  sex?: SexEnum | null;
   photo?: string;
   careInfo?: {
     id: number;
@@ -84,7 +84,7 @@ export interface PetRequestDTO {
   neutered?: boolean | null;
   birthday?: string | null;
   weight?: number | null;
-  sex?: SexEnum;
+  sex?: SexEnum | null;
   photo?: string | null;
   careInfo?: {
     safetyInfo?: string | null;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://app.notion.com/p/uwblueprintexecs/Sprint-Board-4f2ffd2639ac41c4ad0f64818d84d5fa?p=37310f3fb1dc80ca9910f8cb5275b676&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add a new migration that sets sex to allowNull: true on the pets table
* Allow "--" in the sex field instead of mandatory sex
* Put appropriate icons (ie. male, female) for each sex


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a pet
2. Put NULL as the sex field
3. View pet description to confirm


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* That the NULL field works
* Change it to female and then change it back to NULL to test if it works in that instance as well


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR