### PR TITLE
s26/erin/click-assign-modal

### DIFF
--- a/frontend/src/features/pet-profile/components/AssignTaskModal.tsx
+++ b/frontend/src/features/pet-profile/components/AssignTaskModal.tsx
@@ -1,0 +1,177 @@
+import { CloseIcon } from "@chakra-ui/icons";
+import {
+  Flex,
+  IconButton,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
+import React, { useEffect, useMemo, useState } from "react";
+import TaskAPIClient from "../../../APIClients/TaskAPIClient";
+import UserAPIClient from "../../../APIClients/UserAPIClient";
+import Button from "../../../components/common/Button";
+import { User } from "../../../types/UserTypes";
+import UserSelection from "./UserSelection";
+
+interface AssignTaskModalProps {
+  taskId: number;
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const AssignTaskModal = ({
+  taskId,
+  isOpen,
+  onClose,
+  onSuccess,
+}: AssignTaskModalProps): React.ReactElement => {
+  const toast = useToast();
+  const [users, setUsers] = useState<User[]>([]);
+  const [selectedUser, setSelectedUser] = useState<User | null>(null);
+  const [search, setSearch] = useState<string>("");
+  const [page, setPage] = useState<number>(1);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const usersPerPage = 10;
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedUser(null);
+      setSearch("");
+      setPage(1);
+      return;
+    }
+    setLoading(true);
+    const getUsers = async () => {
+      try {
+        const fetchedUsers = await UserAPIClient.get();
+        if (fetchedUsers != null) setUsers(fetchedUsers);
+      } catch (error) {
+        setErrorMessage(`${error}`);
+      } finally {
+        setLoading(false);
+      }
+    };
+    getUsers();
+  }, [isOpen]);
+
+  const filteredUsers = useMemo(
+    () =>
+      users.filter((user) =>
+        `${user.firstName} ${user.lastName}`
+          .toLowerCase()
+          .includes(search.toLowerCase()),
+      ),
+    [users, search],
+  );
+
+  const pagedUsers = filteredUsers.slice(
+    (page - 1) * usersPerPage,
+    page * usersPerPage,
+  );
+
+  const handleSearch = (value: string) => {
+    setSelectedUser(null);
+    setSearch(value);
+    setPage(1);
+  };
+
+  const handleSave = async () => {
+    if (!selectedUser) return;
+    try {
+      await TaskAPIClient.assignUser(taskId, selectedUser.id);
+      toast({
+        title: "Success",
+        description: "Task assigned successfully.",
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
+      onSuccess();
+      onClose();
+    } catch {
+      toast({
+        title: "Error",
+        description: "Failed to assign task.",
+        status: "error",
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent bg="gray.50">
+        <ModalHeader paddingBlock="2rem" paddingInline="2.5rem">
+          <Flex align="center" justify="space-between">
+            <Text m={0} textStyle="h2Mobile" color="gray.700">
+              Assign a Task
+            </Text>
+            <IconButton
+              icon={<CloseIcon boxSize={4} />}
+              variant="ghost"
+              size="sm"
+              onClick={onClose}
+              aria-label="Close modal"
+            />
+          </Flex>
+        </ModalHeader>
+        <ModalBody
+          display="flex"
+          flexDirection="column"
+          gap="2rem"
+          paddingTop="0"
+          paddingBottom="1rem"
+          paddingInline="2.5rem"
+        >
+          <UserSelection
+            search={search}
+            selectedUser={selectedUser}
+            pagedUsers={pagedUsers}
+            filteredUsers={filteredUsers}
+            page={page}
+            errorMessage={errorMessage}
+            usersPerPage={usersPerPage}
+            loading={loading}
+            onSearch={handleSearch}
+            onRowClick={setSelectedUser}
+            onPageChange={setPage}
+            onClearSelection={() => {
+              setSelectedUser(null);
+              setSearch("");
+            }}
+            hasColorLevelMismatch={false}
+          />
+        </ModalBody>
+        <ModalFooter
+          paddingInline="2.5rem"
+          paddingBottom="2.5rem"
+          paddingTop="1rem"
+          borderTop="1px solid"
+          borderColor="gray.200"
+          justifyContent="flex-end"
+        >
+          <Button
+            as="button"
+            type="button"
+            variant="green"
+            onClick={handleSave}
+            disabled={!selectedUser}
+          >
+            Save
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default AssignTaskModal;

--- a/frontend/src/features/pet-profile/components/TaskDetailsModal.tsx
+++ b/frontend/src/features/pet-profile/components/TaskDetailsModal.tsx
@@ -148,12 +148,14 @@ interface TaskDetailsModalProps {
   taskId: number;
   isOpen: boolean;
   onClose: () => void;
+  onAssignClick?: (taskId: number) => void;
 }
 
 const TaskDetailsModal = ({
   taskId,
   isOpen,
   onClose,
+  onAssignClick,
 }: TaskDetailsModalProps): React.ReactElement => {
   const { authenticatedUser } = useContext(AuthContext);
   const toast = useToast();
@@ -291,12 +293,22 @@ const TaskDetailsModal = ({
       return (
         <Flex direction="column" gap="1rem" width="100%">
           {status === null && (
-            <Button variant="dark-blue" size="medium" width="100%">
+            <Button
+              variant="dark-blue"
+              size="medium"
+              width="100%"
+              onClick={() => onAssignClick?.(taskId)}
+            >
               Assign
             </Button>
           )}
           {status === "Assigned" && (
-            <Button variant="dark-blue" size="medium" width="100%">
+            <Button
+              variant="dark-blue"
+              size="medium"
+              width="100%"
+              onClick={() => onAssignClick?.(taskId)}
+            >
               Reassign
             </Button>
           )}

--- a/frontend/src/features/pet-profile/pages/PetProfilePage.tsx
+++ b/frontend/src/features/pet-profile/pages/PetProfilePage.tsx
@@ -23,6 +23,7 @@ import { TableColumn, TableHeader } from "../../../components/common/table";
 import TaskAPIClient from "../../../APIClients/TaskAPIClient";
 import PetProfileTaskTableSection from "./PetProfileTaskTableSection";
 import TaskDetailsModal from "../components/TaskDetailsModal";
+import AssignTaskModal from "../components/AssignTaskModal";
 import CalendarDateSelector from "../../user-profile/components/CalendarDateSelector";
 import Button from "../../../components/common/Button";
 import AssignTaskPage from "./AssignTaskPage";
@@ -69,6 +70,9 @@ const PetProfilePage = (): React.ReactElement => {
   const [loading, setLoading] = useState(true);
   const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedAssignTaskId, setSelectedAssignTaskId] = useState<number | null>(null);
+  const [isAssignModalOpen, setIsAssignModalOpen] = useState(false);
+  const [taskRefreshKey, setTaskRefreshKey] = useState(0);
 
   useEffect(() => {
     const fetchTasks = async () => {
@@ -98,7 +102,7 @@ const PetProfilePage = (): React.ReactElement => {
     };
     fetchTasks();
     setLoading(false);
-  }, [petId, selectedDate, history, location.key]);
+  }, [petId, selectedDate, history, location.key, taskRefreshKey]);
 
   useEffect(() => {
     const fetchPet = async () => {
@@ -157,6 +161,10 @@ const PetProfilePage = (): React.ReactElement => {
         onTaskClick={(taskId) => {
           setSelectedTaskId(taskId);
           setIsModalOpen(true);
+        }}
+        onAssignClick={(taskId) => {
+          setSelectedAssignTaskId(taskId);
+          setIsAssignModalOpen(true);
         }}
       />
     );
@@ -249,6 +257,19 @@ const PetProfilePage = (): React.ReactElement => {
           taskId={selectedTaskId}
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}
+          onAssignClick={(taskId) => {
+            setIsModalOpen(false);
+            setSelectedAssignTaskId(taskId);
+            setIsAssignModalOpen(true);
+          }}
+        />
+      )}
+      {selectedAssignTaskId !== null && (
+        <AssignTaskModal
+          taskId={selectedAssignTaskId}
+          isOpen={isAssignModalOpen}
+          onClose={() => setIsAssignModalOpen(false)}
+          onSuccess={() => setTaskRefreshKey((k) => k + 1)}
         />
       )}
     </>

--- a/frontend/src/features/pet-profile/pages/PetProfilePage.tsx
+++ b/frontend/src/features/pet-profile/pages/PetProfilePage.tsx
@@ -70,7 +70,9 @@ const PetProfilePage = (): React.ReactElement => {
   const [loading, setLoading] = useState(true);
   const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedAssignTaskId, setSelectedAssignTaskId] = useState<number | null>(null);
+  const [selectedAssignTaskId, setSelectedAssignTaskId] = useState<
+    number | null
+  >(null);
   const [isAssignModalOpen, setIsAssignModalOpen] = useState(false);
   const [taskRefreshKey, setTaskRefreshKey] = useState(0);
 

--- a/frontend/src/features/pet-profile/pages/PetProfileTaskTableSection.tsx
+++ b/frontend/src/features/pet-profile/pages/PetProfileTaskTableSection.tsx
@@ -17,7 +17,6 @@ import UserRoles from "../../../constants/UserConstants";
 import { getTaskDetailedStatus, isToday } from "../../../utils/taskStatusUtils";
 
 interface PetProfileTaskTableSectionProps {
-  petId: number;
   tasks: ScheduledTaskDTO[];
   gridTemplateColumns: string;
   authenticatedUser: AuthenticatedUser;

--- a/frontend/src/features/pet-profile/pages/PetProfileTaskTableSection.tsx
+++ b/frontend/src/features/pet-profile/pages/PetProfileTaskTableSection.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useHistory } from "react-router-dom";
 import { Flex, Text, Icon, Grid } from "@chakra-ui/react";
 import { ScheduledTaskDTO, TaskCategory } from "../../../types/TaskTypes";
 import { ReactComponent as GamesIcon } from "../../../assets/icons/games.svg";
@@ -23,21 +22,20 @@ interface PetProfileTaskTableSectionProps {
   gridTemplateColumns: string;
   authenticatedUser: AuthenticatedUser;
   onTaskClick: (taskId: number) => void;
+  onAssignClick: (taskId: number) => void;
 }
 
 const StatusBadge = ({
   task,
-  petId,
   authenticatedUser,
   onTaskClick,
+  onAssignClick,
 }: {
   task: ScheduledTaskDTO;
-  petId: number;
   authenticatedUser: AuthenticatedUser;
   onTaskClick: (taskId: number) => void;
+  onAssignClick: (taskId: number) => void;
 }) => {
-  const history = useHistory();
-
   const isAdminOrBehaviourist =
     authenticatedUser?.role === UserRoles.ADMIN ||
     authenticatedUser?.role === UserRoles.BEHAVIOURIST;
@@ -56,9 +54,10 @@ const StatusBadge = ({
           variant="dark-blue"
           size="medium"
           type="button"
-          onClick={() =>
-            history.push(`/pet-profile/${petId}/assign-task/${task.id}`)
-          }
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+            onAssignClick(task.id);
+          }}
         >
           Assign
         </Button>
@@ -157,11 +156,11 @@ const taskTypeIcons: Record<TaskCategory, React.ElementType> = {
 };
 
 const PetProfileTaskTableSection = ({
-  petId,
   tasks,
   gridTemplateColumns,
   authenticatedUser,
   onTaskClick,
+  onAssignClick,
 }: PetProfileTaskTableSectionProps): React.ReactElement => {
   return (
     <Flex direction="column">
@@ -251,9 +250,9 @@ const PetProfileTaskTableSection = ({
             </Flex>
             <StatusBadge
               task={task}
-              petId={petId}
               authenticatedUser={authenticatedUser}
               onTaskClick={onTaskClick}
+              onAssignClick={onAssignClick}
             />
           </Grid>
         );

--- a/frontend/src/features/user-management/pages/UserManagementPage.tsx
+++ b/frontend/src/features/user-management/pages/UserManagementPage.tsx
@@ -76,7 +76,7 @@ const UserManagementPage = (): React.ReactElement => {
               }
             }
             return user;
-          })
+          }),
         );
         setUsers(usersWithPhotoUrls);
       }

--- a/frontend/src/features/user-profile/components/CalendarDateSelector.tsx
+++ b/frontend/src/features/user-profile/components/CalendarDateSelector.tsx
@@ -74,8 +74,16 @@ const CalendarDateSelector: React.FC<CalendarDateSelectorProps> = ({
 
   return (
     <Flex flexDirection="column" gap="1.5rem" width="100%">
-      <Flex alignItems="center" gap="1rem" justifyContent={rightAction ? "space-between" : "flex-start"}>
-        <Text style={textStyles.h3} margin="0" flex={rightAction ? "1" : undefined}>
+      <Flex
+        alignItems="center"
+        gap="1rem"
+        justifyContent={rightAction ? "space-between" : "flex-start"}
+      >
+        <Text
+          style={textStyles.h3}
+          margin="0"
+          flex={rightAction ? "1" : undefined}
+        >
           {/* getMonth is zero-indexed, so we add one */}
           {MONTH_NUMBER_TO_NAME[visibleWeekStart.getMonth() + 1]}{" "}
           {visibleWeekStart.getFullYear()}
@@ -110,7 +118,11 @@ const CalendarDateSelector: React.FC<CalendarDateSelectorProps> = ({
             size="sm"
           />
         </Flex>
-        {rightAction && <Flex flex="1" justifyContent="flex-end">{rightAction}</Flex>}
+        {rightAction && (
+          <Flex flex="1" justifyContent="flex-end">
+            {rightAction}
+          </Flex>
+        )}
       </Flex>
 
       <Flex justifyContent="space-between" gap="2rem">

--- a/frontend/src/features/user-profile/components/ProfilePhotoModal.tsx
+++ b/frontend/src/features/user-profile/components/ProfilePhotoModal.tsx
@@ -19,7 +19,7 @@ type ModalView = "menu" | "upload" | "preview";
 interface ProfilePhotoModalProps {
   isOpen: boolean;
   profilePhoto: string | undefined;
-  type: "pet" | "user"
+  type: "pet" | "user";
   onClose?: () => void;
   onConfirm?: (file: File | null) => void;
 }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://app.notion.com/p/uwblueprintexecs/Clicking-Assign-doesn-t-bring-up-modal-38910f3fb1dc803aa18ef512421c6541)

## Implementation description
* When an admin clicks the Assign button on an unassigned task in the pet profile task table, it previously navigated to a separate AssignTaskPage. It now opens an AssignTaskModal instead, keeping the user on the pet profile page.
* Created a new `AssignTaskModal` component that wraps the existing `UserSelection` logic in a Chakra modal. On successful assignment, the task list refreshes automatically via a `taskRefreshKey` state increment.
* Also wired the Assign/Reassign buttons inside `TaskDetailsModal` to open the same modal (closing the task details modal first).

## Steps to test
1. Log in as an admin
2. Navigate to any pet profile that has an unassigned task
3. Click the **Assign** button in the task table row, verify a modal opens with a user search list (no page navigation)
4. Select a user and click Save, verify the modal closes and the task row updates to "In Progress"

## What should reviewers focus on?
* The `e.stopPropagation()` on the Assign button in the task table row, this prevents the row's `onClick` (which opens TaskDetailsModal) from firing at the same time as the Assign button click
* Task list refresh logic, `taskRefreshKey` is incremented on successful assignment and added to the `fetchTasks` `useEffect` dependency array



## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR