### PR TITLE
implement migration and backend changes

### DIFF
--- a/backend/typescript/migrations/2026.07.08T01.32.11.add-deleted-at-to-task-templates.ts
+++ b/backend/typescript/migrations/2026.07.08T01.32.11.add-deleted-at-to-task-templates.ts
@@ -1,0 +1,19 @@
+import { DataType } from "sequelize-typescript";
+import { Migration } from "../umzug";
+
+const TABLE_NAME = "task_templates";
+
+export const up: Migration = async ({ context: sequelize }) => {
+  const queryInterface = sequelize.getQueryInterface();
+
+  await queryInterface.addColumn(TABLE_NAME, "deleted_at", {
+    type: DataType.DATE,
+    allowNull: true,
+  });
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  const queryInterface = sequelize.getQueryInterface();
+
+  await queryInterface.removeColumn(TABLE_NAME, "deleted_at");
+};

--- a/backend/typescript/models/taskTemplate.model.ts
+++ b/backend/typescript/models/taskTemplate.model.ts
@@ -14,4 +14,7 @@ export default class TaskTemplate extends Model {
 
   @Column({ type: DataType.TEXT, allowNull: true })
   instruction?: string;
+
+  @Column({ type: DataType.DATE, allowNull: true })
+  deleted_at?: Date;
 }

--- a/backend/typescript/services/implementations/taskTemplateService.ts
+++ b/backend/typescript/services/implementations/taskTemplateService.ts
@@ -37,6 +37,7 @@ class TaskTemplateService implements ITaskTemplateService {
     try {
       const taskTemplates: Array<PgTaskTemplate> = await PgTaskTemplate.findAll(
         {
+          where: { deleted_at: null },
           raw: true,
         },
       );
@@ -114,10 +115,11 @@ class TaskTemplateService implements ITaskTemplateService {
 
   async deleteTaskTemplate(id: string): Promise<string> {
     try {
-      const deleteResult: number | null = await PgTaskTemplate.destroy({
-        where: { id },
-      });
-      if (!deleteResult) {
+      const [updated] = await PgTaskTemplate.update(
+        { deleted_at: new Date() },
+        { where: { id, deleted_at: null } },
+      );
+      if (!updated) {
         throw new NotFoundError(`TaskTemplate id ${id} not found`);
       }
       return id;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Migrate to Soft Delete Task Templates](https://app.notion.com/p/uwblueprintexecs/aecc07aa87f4429dbd4b5c4287531731?v=36a10f3fb1dc8058839b000c0c55db21&p=39110f3fb1dc80e48e49d493780df903&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* created migration to add a nullable deleted_at field to task_templates
* updated taskTemplate.model.ts
* edited deleteTaskTemplate (taskTemplateService.ts) to update deleted_at to now()
* edited getTaskTemplates to exclude task templates with non-null deleted_at

TESTED:
* column shows up in table after migrating
after making and deleting a task template:
* sets the deleted_at in the table to the current time
* template does not show up when trying to add a new task
* old tasks with the template can still be viewed in both the pet profile and user profile
edge case:
* deleted a task template while having the Add Task form open in another tab. I was still able to make a task with the deleted template even though I deleted it first. Do we care about making sure it rejects?

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run the migration
2. Check that the deleted_at column appears
3. Make a task template and assign a task to someone
4. Delete the task template
5. Verify that there is no error and the task still shows up in the pet profile & user profile with the deleted template
6. Verify that the task template does not show up when trying to add a new task


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* ensure that we can see soft-deleted task templates but can't make new tasks with them


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR