### PR TITLE
mobile collapses task management form now with UI matching figma

### DIFF
--- a/frontend/src/components/common/Filter.tsx
+++ b/frontend/src/components/common/Filter.tsx
@@ -252,8 +252,18 @@ const Filter: React.FC<FilterProps> = ({ type, onChange, selected }) => {
                                 textStyle="body"
                                 as="span"
                                 color="gray.700"
+                                display={{ base: "none", md: "inline" }}
                               >
                                 {filter.name}
+                              </Text>
+                              <Text
+                                m={0}
+                                textStyle="body"
+                                as="span"
+                                color="gray.700"
+                                display={{ base: "inline", md: "none" }}
+                              >
+                                {filter.mobileLabel ?? filter.name}
                               </Text>
                               {selectedLabels && (
                                 <>

--- a/frontend/src/components/common/Search.tsx
+++ b/frontend/src/components/common/Search.tsx
@@ -10,7 +10,11 @@ type SearchProps = {
 
 const Search: FC<SearchProps> = ({ search, onChange, placeholder }) => {
   return (
-    <Flex width="100%" maxWidth="250px" flexShrink="0">
+    <Flex
+      width="100%"
+      maxWidth={{ base: "8rem", md: "250px" }}
+      flexShrink={{ base: "1", md: "0" }}
+    >
       <InputGroup>
         <Input
           type="text"

--- a/frontend/src/components/common/table/TableFilterBar.tsx
+++ b/frontend/src/components/common/table/TableFilterBar.tsx
@@ -24,14 +24,25 @@ const TableFilterBar = ({
 }: TableFilterBarProps): React.ReactElement => {
   return (
     <Flex
-      padding="0 2.5rem"
+      padding={{ base: "0 1rem", md: "0 2.5rem" }}
       maxWidth="100vw"
-      justifyContent="space-between"
+      justifyContent={{ base: "flex-start", md: "space-between" }}
       alignItems="center"
-      gap="1rem"
+      gap={{ base: "0.5rem", md: "1rem" }}
     >
-      <Filter type={filterType} onChange={onFilterChange} selected={filters} />
-      <Flex gap="1rem" alignItems="center">
+      <Flex
+        flexShrink={{ base: 0, md: 1 }}
+        maxWidth={{ base: "10rem", md: "none" }}
+        minWidth={{ base: "0", md: "auto" }}
+      >
+        <Filter type={filterType} onChange={onFilterChange} selected={filters} />
+      </Flex>
+      <Flex
+        gap={{ base: "0.5rem", md: "1rem" }}
+        alignItems="center"
+        justifyContent={{ base: "flex-end", md: "flex-start" }}
+        flex={{ base: "1", md: "initial" }}
+      >
         <Search
           placeholder={searchPlaceholder}
           onChange={onSearchChange}

--- a/frontend/src/config/filterConfig.ts
+++ b/frontend/src/config/filterConfig.ts
@@ -74,6 +74,7 @@ const filterConfig: Record<string, FilterSection[]> = {
   taskManagement: [
     {
       name: "Task Category",
+      mobileLabel: "Filter",
       value: "category",
       options: Object.values(TaskCategory),
     },

--- a/frontend/src/features/task-management/components/TaskManagementTable.tsx
+++ b/frontend/src/features/task-management/components/TaskManagementTable.tsx
@@ -1,5 +1,15 @@
 import React from "react";
-import { Text, Flex, Table, Thead, Tr, Th, Td, Tbody } from "@chakra-ui/react";
+import {
+  Text,
+  Flex,
+  Table,
+  Thead,
+  Tr,
+  Th,
+  Td,
+  Tbody,
+  useBreakpointValue,
+} from "@chakra-ui/react";
 import { TableEmptyState } from "../../../components/common/table";
 import { Task } from "../../../types/TaskTypes";
 import TaskManagementTableSection from "./TaskManagementTableSection";
@@ -15,22 +25,40 @@ const TaskManagementTable = ({
   clearFilters,
   onTaskClick,
 }: TaskManagementTableProps): React.ReactElement => {
+  const colSpan = useBreakpointValue({ base: 2, md: 3 }) ?? 3;
+
   return (
-    <Flex width="100%" overflowX="auto">
-      <Table width="100%" minWidth="50rem" textAlign="left" layout="fixed">
+    <Flex width="100%" overflowX={{ base: "hidden", md: "auto" }}>
+      <Table
+        width="100%"
+        minWidth={{ base: "0", md: "50rem" }}
+        textAlign="left"
+        layout="fixed"
+      >
         <Thead borderBottom="1px solid" borderColor="gray.200">
           <Tr borderTop="1px solid" borderColor="gray.200">
-            <Th width="20%" py="1rem" px="2.5rem">
+            <Th width={{ base: "50%", md: "20%" }} py="1rem" px="2.5rem">
               <Text color="gray.800" textStyle="subheading" m={0}>
                 NAME
               </Text>
             </Th>
-            <Th width="20%" py="1rem" px="0">
+            <Th
+              width={{ base: "50%", md: "20%" }}
+              py="1rem"
+              pl={{ base: "1.5rem", md: "0" }}
+              pr="0"
+            >
               <Text color="gray.800" textStyle="subheading" m={0}>
                 CATEGORY
               </Text>
             </Th>
-            <Th width="60%" py="1rem" pr="2.5rem" pl="4rem">
+            <Th
+              display={{ base: "none", md: "table-cell" }}
+              width="60%"
+              py="1rem"
+              pr="2.5rem"
+              pl="4rem"
+            >
               <Text color="gray.800" textStyle="subheading" m={0}>
                 INSTRUCTIONS
               </Text>
@@ -41,7 +69,7 @@ const TaskManagementTable = ({
         {tasks.length === 0 ? (
           <Tbody>
             <Tr>
-              <Td colSpan={3}>
+              <Td colSpan={colSpan}>
                 <TableEmptyState
                   message="No tasks currently match."
                   onClearFilters={clearFilters}

--- a/frontend/src/features/task-management/components/TaskManagementTableSection.tsx
+++ b/frontend/src/features/task-management/components/TaskManagementTableSection.tsx
@@ -1,4 +1,4 @@
-import { Box, Tbody, Td, Text, Tr } from "@chakra-ui/react";
+import { Flex, Tbody, Td, Text, Tr } from "@chakra-ui/react";
 import React from "react";
 import TaskCategoryBadge from "../../../components/common/TaskCategoryBadge";
 import { Task } from "../../../types/TaskTypes";
@@ -26,15 +26,21 @@ const TaskManagementTableSection = ({
               {task.name}
             </Text>
           </Td>
-          <Td width="20%" py="1rem" px="0">
+          <Td width="20%" py="1rem" pl={{ base: "1.5rem", md: "0" }} pr="0">
             <TaskCategoryBadge taskCategory={task.category} />
           </Td>
-          <Td width="60%" py="1rem" pr="2.5rem" pl="4rem">
-            <Box>
+          <Td
+            display={{ base: "none", md: "table-cell" }}
+            width="60%"
+            py="1rem"
+            pr="2.5rem"
+            pl="4rem"
+          >
+            <Flex>
               <Text textStyle="body" m={0} noOfLines={2}>
                 {task.instructions}
               </Text>
-            </Box>
+            </Flex>
           </Td>
         </Tr>
       ))}

--- a/frontend/src/features/task-management/pages/TaskManagementPage.tsx
+++ b/frontend/src/features/task-management/pages/TaskManagementPage.tsx
@@ -1,4 +1,4 @@
-import { useDisclosure } from "@chakra-ui/react";
+import { useDisclosure, useBreakpointValue } from "@chakra-ui/react";
 import React, { useEffect, useMemo, useState } from "react";
 import { useHistory } from "react-router-dom";
 import TaskManagementTable from "../components/TaskManagementTable";
@@ -16,6 +16,11 @@ const TaskManagementPage = (): React.ReactElement => {
   const [filters, setFilters] = useState<Record<string, string[]>>({});
   const [search, setSearch] = useState<string>("");
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const addButtonLabel = useBreakpointValue({ base: "Add", md: "Add Task Template" });
+  const searchPlaceholder = useBreakpointValue({
+    base: "Search",
+    md: "Search for a task...",
+  });
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [page, setPage] = useState<number>(1);
   const numTasksPerPage = 10;
@@ -95,14 +100,14 @@ const TaskManagementPage = (): React.ReactElement => {
         onFilterChange: handleFilterChange,
         search,
         onSearchChange: handleSearchChange,
-        searchPlaceholder: "Search for a task...",
+        searchPlaceholder,
         actionButton: (
           <Button
             variant="dark-blue"
             size="medium"
             onClick={handleAddTaskTemplate}
           >
-            Add Task Template
+            {addButtonLabel}
           </Button>
         ),
       }}

--- a/frontend/src/types/FilterTypes.ts
+++ b/frontend/src/types/FilterTypes.ts
@@ -1,5 +1,6 @@
 export type FilterSection = {
   name: string;
+  mobileLabel?: string;
   options: string[];
   value: string;
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://app.notion.com/p/uwblueprintexecs/Task-Management-Filter-Collapsing-in-Mobile-39110f3fb1dc8002a963c2bdcb285daa?source=copy_link)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* On mobile, the Task Management filter bar now collapses to match Figma: the Filter/Search/Add group stays grouped and right-aligned instead of overflowing, with shortened labels ("Filter" instead of "Task Category", "Search" instead of "Search for a task...", "Add" instead of "Add Task Template") that expand back to full text at tablet widths.
* The task table hides the Instructions column on mobile
* Added an optional `mobileLabel` field to `FilterSection`/`filterConfig` so individual filters can show a shorter label on mobile without changing desktop behavior.
* Tablet/desktop layout and spacing are unchanged from `main`, all new responsive styling is scoped to the mobile (`base`) breakpoint only.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run the app and log in as an Administrator, navigate to Task Management
2. Resize the browser to mobile
3. Confirm the Filter/Search/Add bar stays right-aligned and doesn't overflow or wrap, with shortened labels ("Filter", "Search", "Add").
4. Confirm the table shows only Name and Category columns, each roughly half-width.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Tablet still is the same and uneffected even when the mobile version chaned
* Gap: the top nav bar does not collapse into a hamburger menu on mobile, Users/Tasks/Logs/Profile, can still overflow or crowd the header on narrow screens. Just flagging this as a follow-up rather than in scope here.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR