### PR TITLE
Grant Staff and Animal Behaviourist log access and hide user-info logs from Staff

### DIFF
--- a/backend/typescript/rest/interactionRoutes.ts
+++ b/backend/typescript/rest/interactionRoutes.ts
@@ -33,7 +33,13 @@ interactionRouter.get("/", async (req, res) => {
       return;
     }
 
-    const interactions = await InteractionService.getInteractions();
+    // Staff must not receive interactions about other users' information, so we
+    // resolve the requester's role and let the service filter those types out.
+    const requesterRole = await authService.getUserRoleByToken(accessToken);
+
+    const interactions = await InteractionService.getInteractions(
+      requesterRole,
+    );
     res.status(200).json(interactions);
   } catch (error: unknown) {
     res.status(500).json({

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -255,6 +255,12 @@ class AuthService implements IAuthService {
     }
   }
 
+  async getUserRoleByToken(accessToken: string): Promise<Role> {
+    const decodedIdToken: firebaseAdmin.auth.DecodedIdToken =
+      await firebaseAdmin.auth().verifyIdToken(accessToken, true);
+    return this.userService.getUserRoleByAuthId(decodedIdToken.uid);
+  }
+
   async isAuthorizedByUserId(
     accessToken: string,
     requestedUserId: string,

--- a/backend/typescript/services/implementations/interactionService.ts
+++ b/backend/typescript/services/implementations/interactionService.ts
@@ -1,10 +1,24 @@
+import { Op } from "sequelize";
 import Interaction from "../../models/interaction.model";
 import InteractionType from "../../models/interactionType.model";
 import User from "../../models/user.model";
+import { InteractionTypeEnum, Role } from "../../types";
+
+// Interactions about another user's personal information. Staff are not
+// permitted to see these (permissions sheet); Admin and Animal Behaviourist are.
+const USER_INFO_INTERACTION_TYPES: string[] = [
+  InteractionTypeEnum.CHANGED_USER_NAME,
+  InteractionTypeEnum.CHANGED_USER_COLOR_LEVEL,
+  InteractionTypeEnum.CHANGED_USER_ROLE,
+];
 
 const InteractionService = {
-  async getInteractions() {
+  async getInteractions(requesterRole?: Role) {
     try {
+      // Staff must not receive interactions about other users' information.
+      // Filtering here (server-side) ensures the data never leaves the backend.
+      const excludeUserInfoTypes = requesterRole === Role.STAFF;
+
       const interactions = await Interaction.findAll({
         include: [
           {
@@ -21,6 +35,14 @@ const InteractionService = {
           {
             model: InteractionType,
             attributes: ["action_type"],
+            ...(excludeUserInfoTypes
+              ? {
+                  required: true,
+                  where: {
+                    action_type: { [Op.notIn]: USER_INFO_INTERACTION_TYPES },
+                  },
+                }
+              : {}),
           },
         ],
         order: [["created_at", "DESC"]],

--- a/backend/typescript/services/interfaces/authService.ts
+++ b/backend/typescript/services/interfaces/authService.ts
@@ -78,6 +78,14 @@ interface IAuthService {
   isAuthorizedByRole(accessToken: string, roles: Set<Role>): Promise<boolean>;
 
   /**
+   * Get the role of the user the provided access token was issued to
+   * @param accessToken user's access token
+   * @returns the user's role
+   * @throws Error if token is invalid or the user's role cannot be resolved
+   */
+  getUserRoleByToken(accessToken: string): Promise<Role>;
+
+  /**
    * Determine if the provided access token is valid and issued to the requested user
    * @param accessToken user's access token
    * @param requestedUserId userId of requested user

--- a/frontend/src/components/common/navbar/NavBar.tsx
+++ b/frontend/src/components/common/navbar/NavBar.tsx
@@ -18,10 +18,13 @@ import {
   UserManagementIcon,
 } from "../../../assets/icons";
 import { getLocalStorageObjProperty } from "../../../utils/LocalStorageUtils";
-import AUTHENTICATED_USER_KEY from "../../../constants/AuthConstants";
+import AUTHENTICATED_USER_KEY, {
+  STAFF_BEHAVIOURISTS_ADMIN,
+} from "../../../constants/AuthConstants";
 
 const NavBar = ({ pageName }: { pageName: string }): React.ReactElement => {
   const isAdmin = getCurrentUserRole() === "Administrator";
+  const canViewLogs = STAFF_BEHAVIOURISTS_ADMIN.has(getCurrentUserRole() ?? "");
   const history = useHistory();
 
   const userId = getLocalStorageObjProperty(AUTHENTICATED_USER_KEY, "id");
@@ -72,13 +75,15 @@ const NavBar = ({ pageName }: { pageName: string }): React.ReactElement => {
               ariaLabel="Tasks"
               route={TASK_MANAGEMENT_PAGE}
             />
-            <NavLink
-              text="Logs"
-              icon={LogIcon}
-              ariaLabel="InteractionLogs"
-              route={INTERACTION_LOG_PAGE}
-            />
           </>
+        )}
+        {canViewLogs && (
+          <NavLink
+            text="Logs"
+            icon={LogIcon}
+            ariaLabel="InteractionLogs"
+            route={INTERACTION_LOG_PAGE}
+          />
         )}
         <NavLink
           text="Profile"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/aecc07aa87f4429dbd4b5c4287531731?v=1f810f3fb1dc80c4abe0000c9dba2893&source=copy_link)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* **Part A - nav access (frontend, `NavBar.tsx`):** The "Logs" NavLink was previously nested inside the `{isAdmin && (...)}` block alongside "Users" and "Tasks". Moved "Logs" into its own `{canViewLogs && (...)}` block gated by a new `canViewLogs = STAFF_BEHAVIOURISTS_ADMIN.has(getCurrentUserRole() ?? "")` check. "Users" and "Tasks" remain Administrator-only; "Logs" is now also visible to Staff and Animal Behaviourist (Volunteer still excluded). The route guard already permits S/B/A to load the page.
* **Part B - hide other users' info logs from Staff (backend):** Filtering is done server-side so Staff never receive the data. `getInteractions` now accepts an optional `requesterRole`; when the requester is Staff, the `InteractionType` include gets a `where action_type NOT IN (...)` filter (with `required: true`) excluding the user-info interaction types. The excluded types are the user-info entries that actually exist in `InteractionTypeEnum`: `Changed User Name`, `Changed User Color Level`, `Changed User Role`. (The permissions sheet also lists email / password / phone / pet-tag changes, but there are no corresponding `InteractionTypeEnum` members, so nothing else to exclude.) Admin and Animal Behaviourist are unaffected.
* **Resolving the requester's role:** Added `getUserRoleByToken(accessToken)` to `IAuthService` / `AuthService`, mirroring the existing `isAuthorizedByRole` pattern (verify the Firebase ID token, then `userService.getUserRoleByAuthId(uid)`). `interactionRoutes.ts` calls it after the existing authorization check and passes the role into `getInteractions`.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Log in as Staff or Animal Behaviourist: the "Logs" link now appears in the navbar; "Users" and "Tasks" do not (Admin still sees all three; Volunteer sees none).
2. As Staff, open the Interaction Log: interactions of type "Changed User Name", "Changed User Color Level", and "Changed User Role" should not appear.
3. As Admin or Animal Behaviourist, confirm those same interactions still appear.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* The set of interaction types excluded for Staff (`USER_INFO_INTERACTION_TYPES` in `interactionService.ts`) - confirm it matches the permissions sheet given that email/password/phone/pet-tag interaction types don't currently exist in `InteractionTypeEnum`.
* The new `getUserRoleByToken` on `AuthService` - whether this is the preferred way to surface the requester's role, or if it should be reused elsewhere.
* Note: I verified `yarn tsc --noEmit` and `yarn lint` pass in both workspaces, but I did not run the app or exercise the endpoint against a live DB/Firebase.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
