### PR TITLE
Add error and empty states to interaction log

### DIFF
--- a/frontend/src/components/common/table/TableEmptyState.tsx
+++ b/frontend/src/components/common/table/TableEmptyState.tsx
@@ -3,28 +3,39 @@ import { Flex, Text } from "@chakra-ui/react";
 
 export interface TableEmptyStateProps {
   message: string;
+  linkLabel?: string;
+  onLinkClick?: () => void;
+  /**
+   * @deprecated Backward-compatible alias for a "Clear all" link.
+   * Prefer `linkLabel` + `onLinkClick`.
+   */
   onClearFilters?: () => void;
 }
 
 const TableEmptyState = ({
   message,
+  linkLabel,
+  onLinkClick,
   onClearFilters,
 }: TableEmptyStateProps): React.ReactElement => {
+  const label = linkLabel ?? (onClearFilters ? "Clear all" : undefined);
+  const handleClick = onLinkClick ?? onClearFilters;
+
   return (
     <Flex direction="column" alignItems="center" gap="1rem" my="5rem">
       <Text m={0} textStyle="subheading">
         {message}
       </Text>
-      {onClearFilters && (
+      {label && handleClick && (
         <Text
           m={0}
           textStyle="h3"
           color="blue.500"
           cursor="pointer"
           textDecoration="underline"
-          onClick={onClearFilters}
+          onClick={handleClick}
         >
-          Clear all
+          {label}
         </Text>
       )}
     </Flex>

--- a/frontend/src/features/interaction-log/pages/InteractionLogPage.tsx
+++ b/frontend/src/features/interaction-log/pages/InteractionLogPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { Flex, Grid, Icon, Text, useToast } from "@chakra-ui/react";
+import { Flex, Grid, Icon, Text } from "@chakra-ui/react";
 import {
   TableWrapper,
   TableHeader,
@@ -34,8 +34,8 @@ const columns: TableColumn[] = [
 const gridTemplateColumns = "1fr 1fr 2fr 1fr 1fr";
 
 const InteractionLogPage = (): React.ReactElement => {
-  const toast = useToast();
   const [interactions, setInteractions] = useState<InteractionDTO[]>([]);
+  const [hasError, setHasError] = useState<boolean>(false);
   const [filters, setFilters] = useState<Record<string, string[]>>({});
   const [search, setSearch] = useState<string>("");
   const [selectedInteraction, setSelectedInteraction] =
@@ -46,18 +46,13 @@ const InteractionLogPage = (): React.ReactElement => {
       try {
         const data = await InteractionAPIClient.getInteractions();
         setInteractions(data);
+        setHasError(false);
       } catch (error) {
-        toast({
-          title: "Error",
-          description: "Failed to fetch interactions",
-          status: "error",
-          duration: 3000,
-          isClosable: true,
-        });
+        setHasError(true);
       }
     };
     fetchInteractions();
-  }, [toast]);
+  }, []);
 
   const handleFilterChange = (selectedFilters: Record<string, string[]>) => {
     setFilters(selectedFilters);
@@ -90,7 +85,11 @@ const InteractionLogPage = (): React.ReactElement => {
     return result;
   }, [interactions, search]);
 
-  const isEmpty = filteredLogs.length === 0;
+  // Distinguish a genuinely empty list from a search that filtered everything
+  // out: when the raw list has items but the filtered result is empty, an
+  // active search (the only wired filter) must be excluding them.
+  const isRawEmpty = interactions.length === 0;
+  const isNoMatch = filteredLogs.length === 0;
 
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
@@ -109,6 +108,23 @@ const InteractionLogPage = (): React.ReactElement => {
     });
   };
 
+  let emptyState: React.ReactElement | null = null;
+  if (hasError) {
+    emptyState = (
+      <TableEmptyState message="Unable to load logs. Refresh page." />
+    );
+  } else if (isRawEmpty) {
+    emptyState = <TableEmptyState message="No interactions to display." />;
+  } else if (isNoMatch) {
+    emptyState = (
+      <TableEmptyState
+        message="No interactions currently match."
+        linkLabel="Clear all"
+        onLinkClick={handleClearFilters}
+      />
+    );
+  }
+
   return (
     <>
       <TableWrapper
@@ -126,12 +142,7 @@ const InteractionLogPage = (): React.ReactElement => {
             columns={columns}
             gridTemplateColumns={gridTemplateColumns}
           />
-          {isEmpty ? (
-            <TableEmptyState
-              message="No interactions currently match."
-              onClearFilters={handleClearFilters}
-            />
-          ) : (
+          {emptyState ?? (
             <Flex direction="column" width="100%">
               {filteredLogs.map((log) => (
                 <Grid


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/aecc07aa87f4429dbd4b5c4287531731?v=1f810f3fb1dc80c4abe0000c9dba2893&source=copy_link)


## Implementation description
* The interaction log previously rendered a single empty state (`No interactions currently match.`) whenever `filteredLogs` was empty, so a fetch error looked identical to an empty list. This PR introduces three distinct states, matching the Figma:
  * **Load error** — `Unable to load logs. Refresh page.` (no link)
  * **Genuinely empty** (raw list empty) — `No interactions to display.` (no link)
  * **Filtered no-match** (raw list has items but the search excludes them all) — `No interactions currently match.` with the existing **Clear all** link.
* Added a `hasError` state to `InteractionLogPage`: set to `true` in the `fetchInteractions` catch and reset to `false` on success. The empty-state branch is now: `hasError` → error; else raw list empty → empty; else filtered result empty → no-match; else the table.
* **Toast decision:** dropped the fetch-failure toast in favour of the error *state*. The Figma specifies an error state, and keeping both would double-report the failure. This also removed the now-unused `useToast` import.
* Generalized `TableEmptyState` with optional `linkLabel` + `onLinkClick` so the link text is configurable and the link is fully optional. `onClearFilters` is kept as a backward-compatible alias (maps to label `Clear all` + `onLinkClick`), so the other four call sites (`TaskManagementTable`, `PetListTable`, `UserManagementTable`, `TaskTemplateSelection`) are unchanged.
* Note: the exact copy strings come from the Figma as quoted in the ticket; no Figma source file exists in-repo to re-verify punctuation against, so the ticket's verbatim strings were used.

## Steps to test
1. Open the Interaction Log page.
2. **No-match:** with interactions present, type a search string that matches nothing → shows `No interactions currently match.` with a `Clear all` link; clicking it clears the search.
3. **Genuinely empty:** with an account/state that has zero interactions and no active search → shows `No interactions to display.` (no link).
4. **Load error:** force the `getInteractions` request to fail (e.g. offline / API down) → shows `Unable to load logs. Refresh page.` (no link, no toast).

## What should reviewers focus on?
* The empty-state precedence in `InteractionLogPage` (`hasError` → raw-empty → no-match → table) and whether dropping the toast in favour of the error state is the desired UX.
* The backward-compatible `onClearFilters` alias in `TableEmptyState` — confirm the four unchanged call sites still render their `Clear all` link.
* Filters remain unwired (a separate known bug); `filteredLogs` still only applies the search box, and this PR intentionally does not touch that.

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
