### PR TITLE
Guide admins when a user cannot be deleted due to tasks or interaction logs

### DIFF
--- a/backend/typescript/rest/userRoutes.ts
+++ b/backend/typescript/rest/userRoutes.ts
@@ -17,6 +17,7 @@ import IUserService from "../services/interfaces/userService";
 import { Role, UserDTO } from "../types";
 
 import {
+  ConflictError,
   getErrorMessage,
   NotFoundError,
   INTERNAL_SERVER_ERROR_MESSAGE,
@@ -304,7 +305,7 @@ userRouter.delete("/", async (req, res) => {
         await userService.deleteUserById(Number(userId));
         res.status(204).send();
       } catch (error: unknown) {
-        if (error instanceof NotFoundError) {
+        if (error instanceof NotFoundError || error instanceof ConflictError) {
           res.status(400).json({ error: getErrorMessage(error) });
         } else {
           res.status(500).json({ error: getErrorMessage(error) });
@@ -331,7 +332,11 @@ userRouter.delete("/", async (req, res) => {
         await userService.deleteUserByEmail(email);
         res.status(204).send();
       } catch (error: unknown) {
-        res.status(500).json({ error: getErrorMessage(error) });
+        if (error instanceof NotFoundError || error instanceof ConflictError) {
+          res.status(400).json({ error: getErrorMessage(error) });
+        } else {
+          res.status(500).json({ error: getErrorMessage(error) });
+        }
       }
     }
     return;

--- a/backend/typescript/services/implementations/userService.ts
+++ b/backend/typescript/services/implementations/userService.ts
@@ -7,11 +7,41 @@ import {
   UserDTO,
   UserStatus,
 } from "../../types";
-import { getErrorMessage, NotFoundError } from "../../utilities/errorUtils";
+import {
+  ConflictError,
+  getErrorMessage,
+  NotFoundError,
+} from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
 import PgUser from "../../models/user.model";
+import Task from "../../models/task.model";
+import Interaction from "../../models/interaction.model";
 
 const Logger = logger(__filename);
+
+// Distinct, frontend-matchable message thrown when a user cannot be deleted
+// because deleting them would violate the RESTRICT foreign keys on
+// tasks.user_id (assigned tasks) and/or interactions.actor_id (interaction
+// logs). Kept separate from the "Inactive/Invited" status guard message.
+export const DELETE_BLOCKED_BY_REFERENCES_ERROR =
+  "Cannot delete user with assigned tasks and/or interaction logs.";
+
+// Pre-check that mirrors the RESTRICT foreign keys referencing a user, so we
+// can surface a clear error instead of a raw Postgres FK-constraint error.
+// Note: interactions.target_user_id is ON DELETE SET NULL, so it does not
+// block deletion and is intentionally excluded here.
+const assertUserHasNoBlockingReferences = async (
+  userId: number,
+): Promise<void> => {
+  const [assignedTaskCount, interactionCount] = await Promise.all([
+    Task.count({ where: { user_id: userId } }),
+    Interaction.count({ where: { actor_id: userId } }),
+  ]);
+
+  if (assignedTaskCount > 0 || interactionCount > 0) {
+    throw new ConflictError(DELETE_BLOCKED_BY_REFERENCES_ERROR);
+  }
+};
 
 class UserService implements IUserService {
   /* eslint-disable class-methods-use-this */
@@ -337,6 +367,8 @@ class UserService implements IUserService {
         throw new Error(`userid ${userId} not found.`);
       }
 
+      await assertUserHasNoBlockingReferences(deletedUser.id);
+
       const numDestroyed: number = await PgUser.destroy({
         where: { id: userId },
       });
@@ -393,6 +425,8 @@ class UserService implements IUserService {
       if (!deletedUser) {
         throw new Error(`userid ${firebaseUser.uid} not found.`);
       }
+
+      await assertUserHasNoBlockingReferences(deletedUser.id);
 
       const numDestroyed: number = await PgUser.destroy({
         where: { auth_id: firebaseUser.uid },

--- a/frontend/src/features/user-profile/components/DeleteUserModal.tsx
+++ b/frontend/src/features/user-profile/components/DeleteUserModal.tsx
@@ -45,14 +45,17 @@ const DeleteUserModal: FC<DeleteUserModalProps> = ({
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : "";
       let description = "Unable to delete user, please try again later.";
-      if (
+      if (errorMessage.includes("assigned tasks and/or interaction logs")) {
+        description =
+          "This user has tasks assigned and/or interaction logs, so they cannot be deleted. Reassign their tasks before trying again.";
+      } else if (
         errorMessage.includes("user status must be 'Inactive' or 'Invited'")
       ) {
         description =
           "User must be deactivated before deletion. Please change the user's status to 'Inactive' or 'Invited' first.";
       } else if (errorMessage.includes("foreign key")) {
         description =
-          "All tasks must be unassigned from this user before deletion.";
+          "This user still has tasks assigned and/or interaction logs, so they cannot be deleted.";
       }
       toast({
         title: "Delete User",


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/aecc07aa87f4429dbd4b5c4287531731?v=1f810f3fb1dc80c4abe0000c9dba2893&source=copy_link)


## Implementation description
* A user with assigned tasks and/or interaction logs cannot be deleted, but the UI previously told admins the wrong reason (only that inactive/invited status was required). The real block is a RESTRICT foreign key: `tasks.user_id` (assigned tasks) and `interactions.actor_id` (interaction logs) reference the user with no `ON DELETE` action, so `PgUser.destroy` fails with a raw Postgres FK-constraint error. The route's `status === "Active"` guard only blocks *Active* users; an Inactive/Invited user with tasks/interactions previously hit the raw FK error and surfaced as a 500.
* Backend: added a shared pre-check `assertUserHasNoBlockingReferences` in `userService.ts`, called in both `deleteUserById` and `deleteUserByEmail` before `destroy`. It counts `tasks.user_id` and `interactions.actor_id` for the user and throws a distinct `ConflictError` with the message `"Cannot delete user with assigned tasks and/or interaction logs."` `interactions.target_user_id` is `ON DELETE SET NULL`, so it does not block deletion and is intentionally excluded.
* Backend: `DELETE /users` routes now return `400` for `ConflictError` (previously would have been `500`), alongside the existing `NotFoundError` handling.
* Frontend: `DeleteUserModal` matches the new message substring `"assigned tasks and/or interaction logs"` and shows a guided description. The existing Inactive/Invited status branch is unchanged; the generic `foreign key` fallback copy was updated to also mention interaction logs.


## Steps to test
1. Log in as an administrator.
2. Set a user to Inactive/Invited status and ensure they have at least one assigned task and/or at least one interaction log where they are the actor.
3. Attempt to delete that user from their profile.
4. Expect the delete to be blocked with the toast: "This user has tasks assigned and/or interaction logs, so they cannot be deleted. Reassign their tasks before trying again."
5. Reassign/remove those references and confirm the user can then be deleted.


## What should reviewers focus on?
* Whether "interaction logs" should include logs where the user is the *target* (`target_user_id`). Those are `SET NULL` on delete and do not block deletion, so they are excluded from the pre-check; confirm that matches product intent.
* The exact error string is the contract between backend (`DELETE_BLOCKED_BY_REFERENCES_ERROR`) and the frontend `includes(...)` match; keep them in sync if changed.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
